### PR TITLE
Customer update on platform. Fixed quote item duplication

### DIFF
--- a/Observer/CheckoutCart/AddProductToCartAfter.php
+++ b/Observer/CheckoutCart/AddProductToCartAfter.php
@@ -17,6 +17,7 @@ class AddProductToCartAfter extends CheckoutCartAbstract implements ObserverInte
      * @param \Swarming\SubscribePro\Model\Config\General $generalConfig
      * @param \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager
      * @param \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater
+     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
      * @param \Swarming\SubscribePro\Helper\Product $productHelper
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\App\State $appState
@@ -27,6 +28,7 @@ class AddProductToCartAfter extends CheckoutCartAbstract implements ObserverInte
         \Swarming\SubscribePro\Model\Config\General $generalConfig,
         \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager,
         \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater,
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Swarming\SubscribePro\Helper\Product $productHelper,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\App\State $appState,
@@ -38,6 +40,7 @@ class AddProductToCartAfter extends CheckoutCartAbstract implements ObserverInte
             $generalConfig,
             $platformProductManager,
             $subscriptionOptionUpdater,
+            $productRepository,
             $productHelper,
             $messageManager,
             $appState,

--- a/Observer/CheckoutCart/CartUpdateItemsAfter.php
+++ b/Observer/CheckoutCart/CartUpdateItemsAfter.php
@@ -28,7 +28,7 @@ class CartUpdateItemsAfter extends CheckoutCartAbstract implements ObserverInter
         /** @var \Magento\Framework\DataObject $infoDataObject */
         $infoDataObject = $observer->getData('info');
 
-        foreach ($quote->getAllVisibleItems() as $quoteItem) {
+        foreach ($quote->getAllItems() as $quoteItem) {
             $subscriptionParams = $this->getSubscriptionParams($quoteItem, $infoDataObject);
             try {
                 $this->updateQuoteItem($quoteItem, $subscriptionParams);
@@ -46,7 +46,8 @@ class CartUpdateItemsAfter extends CheckoutCartAbstract implements ObserverInter
      */
     protected function getSubscriptionParams(QuoteItem $quoteItem, $infoDataObject)
     {
-        $quoteItemParams = $infoDataObject->getData($quoteItem->getItemId());
+        $quoteItemId = $quoteItem->getParentItemId() ?: $quoteItem->getItemId();
+        $quoteItemParams = $infoDataObject->getData($quoteItemId);
 
         return isset($quoteItemParams[SubscriptionOptionProcessor::KEY_SUBSCRIPTION_OPTION])
             ? $quoteItemParams[SubscriptionOptionProcessor::KEY_SUBSCRIPTION_OPTION]

--- a/Observer/CheckoutCart/CheckoutCartAbstract.php
+++ b/Observer/CheckoutCart/CheckoutCartAbstract.php
@@ -27,6 +27,11 @@ abstract class CheckoutCartAbstract implements ObserverInterface
     protected $subscriptionOptionUpdater;
 
     /**
+     * @var \Magento\Catalog\Api\ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
      * @var \Swarming\SubscribePro\Helper\Product
      */
     protected $productHelper;
@@ -50,6 +55,7 @@ abstract class CheckoutCartAbstract implements ObserverInterface
      * @param \Swarming\SubscribePro\Model\Config\General $generalConfig
      * @param \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager
      * @param \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater
+     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
      * @param \Swarming\SubscribePro\Helper\Product $productHelper
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\App\State $appState
@@ -59,6 +65,7 @@ abstract class CheckoutCartAbstract implements ObserverInterface
         \Swarming\SubscribePro\Model\Config\General $generalConfig,
         \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager,
         \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater,
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Swarming\SubscribePro\Helper\Product $productHelper,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\App\State $appState,
@@ -67,6 +74,7 @@ abstract class CheckoutCartAbstract implements ObserverInterface
         $this->generalConfig = $generalConfig;
         $this->platformProductManager = $platformProductManager;
         $this->subscriptionOptionUpdater = $subscriptionOptionUpdater;
+        $this->productRepository = $productRepository;
         $this->productHelper = $productHelper;
         $this->messageManager = $messageManager;
         $this->appState = $appState;
@@ -80,11 +88,11 @@ abstract class CheckoutCartAbstract implements ObserverInterface
     protected function updateQuoteItem(QuoteItem $quoteItem, array $quoteItemParams)
     {
         $product = $quoteItem->getProduct();
-        if (!$this->productHelper->isSubscriptionEnabled($product)) {
-            return;
+        if ($quoteItem->getParentItem() && $quoteItem->getParentItem()->getProduct()) {
+            $product = $quoteItem->getParentItem()->getProduct();
         }
 
-        if ($product->getParentItemId()) {
+        if (!$this->productHelper->isSubscriptionEnabled($product)) {
             return;
         }
 

--- a/Observer/CheckoutCart/UpdateProductAfter.php
+++ b/Observer/CheckoutCart/UpdateProductAfter.php
@@ -17,6 +17,7 @@ class UpdateProductAfter extends CheckoutCartAbstract implements ObserverInterfa
      * @param \Swarming\SubscribePro\Model\Config\General $generalConfig
      * @param \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager
      * @param \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater
+     * @param \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
      * @param \Swarming\SubscribePro\Helper\Product $productHelper
      * @param \Magento\Framework\Message\ManagerInterface $messageManager
      * @param \Magento\Framework\App\State $appState
@@ -27,6 +28,7 @@ class UpdateProductAfter extends CheckoutCartAbstract implements ObserverInterfa
         \Swarming\SubscribePro\Model\Config\General $generalConfig,
         \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager,
         \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater $subscriptionOptionUpdater,
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Swarming\SubscribePro\Helper\Product $productHelper,
         \Magento\Framework\Message\ManagerInterface $messageManager,
         \Magento\Framework\App\State $appState,
@@ -38,6 +40,7 @@ class UpdateProductAfter extends CheckoutCartAbstract implements ObserverInterfa
             $generalConfig,
             $platformProductManager,
             $subscriptionOptionUpdater,
+            $productRepository,
             $productHelper,
             $messageManager,
             $appState,

--- a/Plugin/Customer/CustomerRepository.php
+++ b/Plugin/Customer/CustomerRepository.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Swarming\SubscribePro\Plugin\Customer;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class CustomerRepository
+{
+    /**
+     * @var \Swarming\SubscribePro\Platform\Manager\Customer
+     */
+    protected $platformCustomerManager;
+
+    /**
+     * @var \Swarming\SubscribePro\Platform\Service\Customer
+     */
+    protected $platformCustomerService;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @param \Swarming\SubscribePro\Platform\Manager\Customer $platformCustomerManager
+     * @param \Swarming\SubscribePro\Platform\Service\Customer $platformCustomerService
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        \Swarming\SubscribePro\Platform\Manager\Customer $platformCustomerManager,
+        \Swarming\SubscribePro\Platform\Service\Customer $platformCustomerService,
+        \Psr\Log\LoggerInterface $logger
+    ) {
+        $this->platformCustomerManager = $platformCustomerManager;
+        $this->platformCustomerService = $platformCustomerService;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param \Magento\Customer\Api\CustomerRepositoryInterface $subject
+     * @param \Closure $proceed
+     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @param string $passwordHash
+     * @return \Magento\Customer\Api\Data\CustomerInterface
+     */
+    public function aroundSave(CustomerRepositoryInterface $subject, \Closure $proceed, CustomerInterface $customer, $passwordHash = null)
+    {
+        $platformCustomer = $this->getPlatformCustomer($customer);
+
+        $customer = $proceed($customer, $passwordHash);
+
+        if ($platformCustomer) {
+            $this->updatePlatformCustomer($customer, $platformCustomer);
+        }
+        return $customer;
+    }
+
+    /**
+     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @return \SubscribePro\Service\Customer\CustomerInterface|null
+     */
+    protected function getPlatformCustomer($customer)
+    {
+        try {
+            $platformCustomer = $this->platformCustomerManager->getCustomerById($customer->getId(), false, $customer->getWebsiteId());
+        } catch (NoSuchEntityException $e) {
+            $platformCustomer = null;
+        } catch (\Exception $e) {
+            $this->logger->critical($e);
+            $platformCustomer = null;
+        }
+
+        return $platformCustomer;
+    }
+
+    /**
+     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @param \SubscribePro\Service\Customer\CustomerInterface $platformCustomer
+     */
+    protected function updatePlatformCustomer($customer, $platformCustomer)
+    {
+        try {
+            $this->importCustomerData($platformCustomer, $customer);
+            $this->platformCustomerService->saveCustomer($platformCustomer, $customer->getWebsiteId());
+        } catch (\Exception $e) {
+            $this->logger->critical($e);
+        }
+    }
+
+    /**
+     * @param \SubscribePro\Service\Customer\CustomerInterface $platformCustomer
+     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     */
+    protected function importCustomerData(PlatformCustomerInterface $platformCustomer, CustomerInterface $customer)
+    {
+        $platformCustomer->setFirstName($customer->getFirstname());
+        $platformCustomer->setLastName($customer->getLastname());
+        $platformCustomer->setEmail($customer->getEmail());
+    }
+}

--- a/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
@@ -53,7 +53,7 @@ class VaultDetailsHandlerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
         $this->paymentTokenFactoryMock = $this->getMockBuilder(PaymentTokenInterfaceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])->getMock();
+            ->setMethods(['create', 'getType'])->getMock();
         $this->paymentExtensionFactoryMock = $this->getMockBuilder(OrderPaymentExtensionInterfaceFactory::class)
             ->disableOriginalConstructor()
             ->setMethods(['create'])->getMock();

--- a/Test/Unit/Helper/QuoteTest.php
+++ b/Test/Unit/Helper/QuoteTest.php
@@ -113,7 +113,10 @@ class QuoteTest extends \PHPUnit_Framework_TestCase
      */
     private function createQuoteItemMock()
     {
-        return $this->getMockBuilder(QuoteItem::class)->disableOriginalConstructor()->getMock();
+        return $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['__clone', '__wakeUp'])
+            ->getMock();
     }
 
     /**

--- a/Test/Unit/Plugin/Customer/CustomerRepositoryTest.php
+++ b/Test/Unit/Plugin/Customer/CustomerRepositoryTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Swarming\SubscribePro\Test\Unit\Plugin\Checkout;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Swarming\SubscribePro\Plugin\Customer\CustomerRepository as CustomerRepositoryPlugin;
+use Swarming\SubscribePro\Platform\Manager\Customer as PlatformCustomerManager;
+use Swarming\SubscribePro\Platform\Service\Customer as PlatformCustomerService;
+use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Psr\Log\LoggerInterface;
+
+class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Swarming\SubscribePro\Platform\Manager\Customer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $platformCustomerManager;
+
+    /**
+     * @var \Swarming\SubscribePro\Platform\Service\Customer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $platformCustomerService;
+
+    /**
+     * @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $logger;
+
+    /**
+     * @var \Swarming\SubscribePro\Plugin\Customer\CustomerRepository
+     */
+    protected $customerRepositoryPlugin;
+
+    protected function setUp()
+    {
+        $this->platformCustomerManager = $this->getMockBuilder(PlatformCustomerManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->platformCustomerService = $this->getMockBuilder(PlatformCustomerService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+
+        $this->customerRepositoryPlugin = new CustomerRepositoryPlugin(
+            $this->platformCustomerManager,
+            $this->platformCustomerService,
+            $this->logger
+        );
+    }
+
+    public function testAroundSaveIfPlatformCustomerNotFound()
+    {
+        $customerId = 123;
+        $websiteId = 12;
+        $firstName = 'User';
+        $lastName = 'Test';
+        $email = 'user@email.test';
+
+        $customer = $this->getCustomerMock($customerId, $websiteId);
+        $savedCustomer = $this->getSavedCustomerMock($firstName, $lastName, $email, $websiteId);
+        $proceed = $this->createProceedCallback($savedCustomer);
+
+        $this->platformCustomerManager->expects($this->once())
+            ->method('getCustomerById')
+            ->with($customerId, false, $websiteId)
+            ->willThrowException(new NoSuchEntityException());
+
+        $this->platformCustomerService->expects($this->never())->method('saveCustomer');
+        $this->logger->expects($this->never())->method('critical');
+
+        $subject = $this->getMockBuilder(CustomerRepositoryInterface::class)->getMock();
+
+        $this->assertSame(
+            $savedCustomer,
+            $this->customerRepositoryPlugin->aroundSave($subject, $proceed, $customer, null)
+        );
+    }
+
+    public function testAroundSaveIfExceptionOnLoadCustomer()
+    {
+        $customerId = 321;
+        $websiteId = 4;
+        $firstName = 'User';
+        $lastName = 'Test';
+        $email = 'user@email.test';
+
+        $customer = $this->getCustomerMock($customerId, $websiteId);
+        $savedCustomer = $this->getSavedCustomerMock($firstName, $lastName, $email, $websiteId);
+
+        $proceed = $this->createProceedCallback($savedCustomer);
+
+        $exception = new \Exception();
+
+        $this->platformCustomerManager->expects($this->once())
+            ->method('getCustomerById')
+            ->with($customerId, false, $websiteId)
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with($exception);
+
+        $this->platformCustomerService->expects($this->never())->method('saveCustomer');
+
+        $subject = $this->getMockBuilder(CustomerRepositoryInterface::class)->getMock();
+
+        $this->assertSame(
+            $savedCustomer,
+            $this->customerRepositoryPlugin->aroundSave($subject, $proceed, $customer, null)
+        );
+    }
+
+    public function testAroundSaveIfExceptionOnSaveCustomer()
+    {
+        $customerId = 848;
+        $websiteId = 1;
+        $firstName = 'User';
+        $lastName = 'Test';
+        $email = 'user@email.test';
+
+        $customer = $this->getCustomerMock($customerId, $websiteId);
+        $savedCustomer = $this->getSavedCustomerMock($firstName, $lastName, $email, $websiteId);
+        $platformCustomer = $this->getPlatformCustomerMock($firstName, $lastName, $email);
+
+        $proceed = $this->createProceedCallback($savedCustomer);
+
+        $exception = new \Exception();
+
+        $this->platformCustomerManager->expects($this->once())
+            ->method('getCustomerById')
+            ->with($customerId, false, $websiteId)
+            ->willReturn($platformCustomer);
+
+        $this->platformCustomerService->expects($this->once())
+            ->method('saveCustomer')
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with($exception);
+
+        $subject = $this->getMockBuilder(CustomerRepositoryInterface::class)->getMock();
+
+        $this->assertSame(
+            $savedCustomer,
+            $this->customerRepositoryPlugin->aroundSave($subject, $proceed, $customer, null)
+        );
+    }
+
+    public function testAroundSave()
+    {
+        $customerId = 243;
+        $websiteId = 2;
+        $firstName = 'User';
+        $lastName = 'Test';
+        $email = 'user@email.test';
+
+        $customer = $this->getCustomerMock($customerId, $websiteId);
+        $savedCustomer = $this->getSavedCustomerMock($firstName, $lastName, $email, $websiteId);
+        $platformCustomer = $this->getPlatformCustomerMock($firstName, $lastName, $email);
+
+        $proceed = $this->createProceedCallback($savedCustomer);
+
+        $this->platformCustomerManager->expects($this->once())
+            ->method('getCustomerById')
+            ->with($customerId, false, $websiteId)
+            ->willReturn($platformCustomer);
+
+        $this->platformCustomerService->expects($this->once())
+            ->method('saveCustomer')
+            ->with($platformCustomer, $websiteId)
+            ->willReturn($platformCustomer);
+
+        $this->logger->expects($this->never())->method('critical');
+        $subject = $this->getMockBuilder(CustomerRepositoryInterface::class)->getMock();
+
+        $this->assertSame(
+            $savedCustomer,
+            $this->customerRepositoryPlugin->aroundSave($subject, $proceed, $customer, null)
+        );
+    }
+
+    /**
+     * @param string $customerId
+     * @param string $websiteId
+     * @return \Magento\Customer\Api\Data\CustomerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getCustomerMock($customerId, $websiteId)
+    {
+        $customer = $this->getMockBuilder(CustomerInterface::class)->getMock();
+
+        $customer->expects($this->atLeastOnce())
+            ->method('getId')
+            ->willReturn($customerId);
+
+        $customer->expects($this->atLeastOnce())
+            ->method('getWebsiteId')
+            ->willReturn($websiteId);
+
+        return $customer;
+    }
+
+    /**
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $email
+     * @param string $websiteId
+     * @return \Magento\Customer\Api\Data\CustomerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getSavedCustomerMock($firstName, $lastName, $email, $websiteId)
+    {
+        $customer = $this->getMockBuilder(CustomerInterface::class)->getMock();
+
+        $customer->expects($this->any())
+            ->method('getWebsiteId')
+            ->willReturn($websiteId);
+
+        $customer->expects($this->any())
+            ->method('getFirstname')
+            ->willReturn($firstName);
+
+        $customer->expects($this->any())
+            ->method('getLastname')
+            ->willReturn($lastName);
+
+        $customer->expects($this->any())
+            ->method('getEmail')
+            ->willReturn($email);
+
+        return $customer;
+    }
+
+    /**
+     * @param string $firstName
+     * @param string $lastName
+     * @param string $email
+     * @return \SubscribePro\Service\Customer\CustomerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getPlatformCustomerMock($firstName, $lastName, $email)
+    {
+        $platformCustomer = $this->getMockBuilder(PlatformCustomerInterface::class)->getMock();
+
+        $platformCustomer->expects($this->any())
+            ->method('setFirstname')
+            ->willReturn($firstName);
+
+        $platformCustomer->expects($this->any())
+            ->method('setLastname')
+            ->willReturn($lastName);
+
+        $platformCustomer->expects($this->any())
+            ->method('setEmail')
+            ->willReturn($email);
+
+        return $platformCustomer;
+    }
+
+    /**
+     * @param \Magento\Customer\Api\Data\CustomerInterface $resultCustomer
+     * @return callable
+     */
+    protected function createProceedCallback($resultCustomer)
+    {
+        return function ($customer, $passwordHash) use ($resultCustomer) {
+            return $resultCustomer;
+        };
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -73,6 +73,10 @@
         </arguments>
     </type>
 
+    <type name="Magento\Customer\Api\CustomerRepositoryInterface">
+        <plugin name="subscribepro_customer" type="Swarming\SubscribePro\Plugin\Customer\CustomerRepository" />
+    </type>
+
     <type name="Magento\SalesRule\Model\Validator">
         <plugin name="subscribepro_discount" type="Swarming\SubscribePro\Plugin\SalesRule\Validator" sortOrder="50" />
     </type>


### PR DESCRIPTION
Change platform customer email​ on update customer account
Fixed: Simple item gets duplicated in the Quote