### PR TITLE
Added the group id to the fields passed on customer update

### DIFF
--- a/Plugin/Customer/CustomerRepository.php
+++ b/Plugin/Customer/CustomerRepository.php
@@ -99,5 +99,6 @@ class CustomerRepository
         $platformCustomer->setFirstName($customer->getFirstname());
         $platformCustomer->setLastName($customer->getLastname());
         $platformCustomer->setEmail($customer->getEmail());
+        $platformCustomer->setMagentoCustomerGroupId($customer->getGroupId());
     }
 }


### PR DESCRIPTION
Whenever a customer is updated, the group_id is sent along with the other information.

This one was really tricky to find, as I eventually tracked it down to a plugin that is sitting on top of the normal CustomerRepository.