### PR TITLE
Update module version in module.xml

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Swarming_SubscribePro" setup_version="1.0.10">
+    <module name="Swarming_SubscribePro" setup_version="1.0.11">
         <sequence>
             <module name="Magento_Customer"/>
             <module name="Magento_Checkout"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Swarming_SubscribePro" setup_version="1.0.0">
+    <module name="Swarming_SubscribePro" setup_version="1.0.10">
         <sequence>
             <module name="Magento_Customer"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
See https://github.com/subscribepro/subscribepro-magento2-ext/issues/21 . Would need to get this merged in and then tag a new release to sync the version in Magento up with the released version of the module. We should probably look at adding the version into the composer.json as well. 

I wasn't sure what branch this should go to. We can adjust it if need be. I also can't remember if you can re-release, so may need to change this back to 1.0.10 and make a new release, however, I feel it would be cleaner to actually bump to 1.0.11 and then keep the trend going in future releases. 