### PR TITLE
[#150188861] Fix several issues relating to admin ordering on a multistore

### DIFF
--- a/Block/Adminhtml/Order/Create/Items/Grid.php
+++ b/Block/Adminhtml/Order/Create/Items/Grid.php
@@ -67,6 +67,7 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid
         $this->productHelper = $productHelper;
         $this->quoteItemHelper = $quoteItemHelper;
         $this->platformProductManager = $platformProductManager;
+        $this->sessionQuote = $sessionQuote;
         parent::__construct($context, $sessionQuote, $orderCreate, $priceCurrency, $wishlistFactory, $giftMessageSave, $taxConfig, $taxData, $messageHelper, $stockRegistry, $stockState, $data);
     }
 
@@ -90,7 +91,8 @@ class Grid extends \Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid
     public function getSubscriptionProduct(Item $quoteItem)
     {
         $sku = $quoteItem->getProduct()->getData(ProductInterface::SKU);
-        $subscriptionProduct = $this->platformProductManager->getProduct($sku);
+
+        $subscriptionProduct = $this->platformProductManager->getProduct($sku, $this->sessionQuote->getStore()->getWebsiteId());
         return $subscriptionProduct->toArray();
     }
 

--- a/Model/Quote/ItemSubscriptionDiscount.php
+++ b/Model/Quote/ItemSubscriptionDiscount.php
@@ -114,7 +114,7 @@ class ItemSubscriptionDiscount
     protected function getPlatformProduct(QuoteItem $item)
     {
         $sku = $item->getProduct()->getData(ProductInterface::SKU);
-        return $this->platformProductManager->getProduct($sku);
+        return $this->platformProductManager->getProduct($sku, $item->getQuote()->getStore()->getWebsiteId());
     }
 
     /**

--- a/Platform/Manager/Customer.php
+++ b/Platform/Manager/Customer.php
@@ -42,6 +42,8 @@ class Customer
     public function getCustomerById($customerId, $createIfNotExist = false, $websiteId = null)
     {
         $customer = $this->customerRepository->getById($customerId);
+        // If $websiteId is null, use the customer's websiteId as a fallback
+        $websiteId = $websiteId !== null ? $websiteId : $customer->getWebsiteId();
         return $this->getCustomer($customer->getEmail(), $createIfNotExist, $websiteId);
     }
 

--- a/Platform/SdkFactory.php
+++ b/Platform/SdkFactory.php
@@ -15,7 +15,6 @@ class SdkFactory
         $config = isset($data['config']) && is_array($data['config'])
             ? $data['config']
             : [];
-
         return new Sdk($config);
     }
 }

--- a/Plugin/Quote/QuoteItemUpdater.php
+++ b/Plugin/Quote/QuoteItemUpdater.php
@@ -108,7 +108,7 @@ class QuoteItemUpdater
             return;
         }
 
-        $platformProduct = $this->getPlatformProduct($product);
+        $platformProduct = $this->getPlatformProduct($product, $quoteItem->getQuote()->getStore()->getWebsiteId());
         if (!$platformProduct) {
             return;
         }
@@ -127,13 +127,14 @@ class QuoteItemUpdater
 
     /**
      * @param \Magento\Catalog\Model\Product $product
+     * @param int|null $websiteId
      * @return \Swarming\SubscribePro\Api\Data\ProductInterface|null
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    protected function getPlatformProduct($product)
+    protected function getPlatformProduct($product, $websiteId = null)
     {
         try {
-            $platformProduct = $this->platformProductManager->getProduct($product->getData(ProductInterface::SKU));
+            $platformProduct = $this->platformProductManager->getProduct($product->getData(ProductInterface::SKU), $websiteId);
         } catch (NoSuchEntityException $e) {
             if ($this->appState->getMode() === AppState::MODE_DEVELOPER) {
                 throw $e;

--- a/view/adminhtml/requirejs-config.js
+++ b/view/adminhtml/requirejs-config.js
@@ -1,0 +1,9 @@
+var config = {
+	config: {
+		mixins: {
+			"Magento_Sales/order/create/form": {
+				"Swarming_SubscribePro/js/admin-order-refresh": true
+			}
+		}
+	}
+};

--- a/view/adminhtml/web/js/admin-order-refresh.js
+++ b/view/adminhtml/web/js/admin-order-refresh.js
@@ -1,0 +1,22 @@
+define(['mage/utils/wrapper', "Swarming_SubscribePro/js/model/payment/config"], function(wrapper, config){
+    'use strict';
+
+    return function() {
+        var setStoreId = window.order.setStoreId;
+        var setStoreId = wrapper.wrap(setStoreId, function(original, id) {
+            original(id);
+            // The store ID is set when the page loads as store 1.
+            // The SP configuration is pulled based on that store ID and is
+            // stored in a javascript variable to be used during the payment
+            // step.
+            // The page is dynamically changed without a reload throughout the
+            // checkout process and I couldn't figure out how to update the
+            // config. A simple page refresh retains the checkout progress and
+            // reloads the config using the correct store ID.
+            location.reload();
+        });
+        window.order.setStoreId = setStoreId;
+
+        return window.order;
+    }
+});


### PR DESCRIPTION
Specifically, during admin ordering the website ID was not being set properly so the SP configuration was always being loaded from the default store (id: 1). 