### PR TITLE
[#155189997] Allow $0 totals for frontend and recurring orders

### DIFF
--- a/Model/Checks/ZeroTotal.php
+++ b/Model/Checks/ZeroTotal.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Swarming\SubscribePro\Model\Checks;
+
+use Magento\Payment\Model\MethodInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Payment\Model\Checks\ZeroTotal as MagentoZeroTotal;
+
+/**
+ * Checks that order total is meaningful
+ *
+ * @api
+ * @since 100.0.2
+ */
+class ZeroTotal  extends MagentoZeroTotal
+{
+    /**
+     * Check whether payment method is applicable to quote
+     * Purposed to allow use in controllers some logic that was implemented in blocks only before
+     *
+     * @param MethodInterface $paymentMethod
+     * @param \Magento\Quote\Model\Quote $quote
+     * @return bool
+     */
+    public function isApplicable(MethodInterface $paymentMethod, Quote $quote)
+    {
+        return !($quote->getBaseGrandTotal() < 0.0001 && $paymentMethod->getCode() != 'free' && $paymentMethod->getCode() != 'subscribe_pro_vault');
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -7,6 +7,7 @@
     <preference for="Swarming\SubscribePro\Model\CatalogRule\InspectorInterface" type="Swarming\SubscribePro\Model\CatalogRule\Inspector" />
     <preference for="Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid" type="Swarming\SubscribePro\Block\Adminhtml\Order\Create\Items\Grid" />
     <preference for="Magento\SalesRule\Model\Rule\Condition\Product" type="Swarming\SubscribePro\Model\Rule\Condition\Product" />
+    <preference for="Magento\Payment\Model\Checks\ZeroTotal" type="Swarming\SubscribePro\Model\Checks\ZeroTotal" />
 
     <type name="Swarming\SubscribePro\Platform\Platform">
         <arguments>


### PR DESCRIPTION
Override default Magento ZeroTotal class that determines whether a payment method can be used for a $0 total.