### PR TITLE
[#155289622] Update PHPUnit tests to extend correct class

### DIFF
--- a/Test/Unit/Controller/Adminhtml/Config/TestConnectionTest.php
+++ b/Test/Unit/Controller/Adminhtml/Config/TestConnectionTest.php
@@ -12,7 +12,7 @@ use Swarming\SubscribePro\Controller\Adminhtml\Config\TestConnection;
 use Swarming\SubscribePro\Model\Config\Platform as PlatformConfig;
 use Magento\Framework\Controller\Result\Json as ResultJson;
 
-class TestConnectionTest extends \PHPUnit_Framework_TestCase
+class TestConnectionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Adminhtml\Config\TestConnection

--- a/Test/Unit/Controller/Cards/EditTest.php
+++ b/Test/Unit/Controller/Cards/EditTest.php
@@ -13,7 +13,7 @@ use Magento\Framework\View\Page\Config as PageConfig;
 use Magento\Framework\View\Page\Title as PageTitle;
 use Magento\Framework\View\Element\Html\Links as NavigationBlock;
 
-class EditTest extends \PHPUnit_Framework_TestCase
+class EditTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Cards\Edit

--- a/Test/Unit/Controller/Cards/NewActionTest.php
+++ b/Test/Unit/Controller/Cards/NewActionTest.php
@@ -7,7 +7,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Swarming\SubscribePro\Controller\Cards\NewAction;
 use Magento\Framework\Controller\Result\Forward as ResultForward;
 
-class NewActionTest extends \PHPUnit_Framework_TestCase
+class NewActionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Cards\NewAction

--- a/Test/Unit/Controller/Cards/SaveTest.php
+++ b/Test/Unit/Controller/Cards/SaveTest.php
@@ -16,7 +16,7 @@ use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\Data\Form\FormKey\Validator as FormKeyValidator;
 use Swarming\SubscribePro\Model\Vault\Form as VaultForm;
 
-class SaveTest extends \PHPUnit_Framework_TestCase
+class SaveTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Cards\Save

--- a/Test/Unit/Controller/Customer/SubscriptionsTest.php
+++ b/Test/Unit/Controller/Customer/SubscriptionsTest.php
@@ -11,7 +11,7 @@ use Magento\Framework\View\Page\Config as PageConfig;
 use Magento\Framework\View\Page\Title as PageTitle;
 use Swarming\SubscribePro\Model\Config\General as GeneralConfig;
 
-class SubscriptionsTest extends \PHPUnit_Framework_TestCase
+class SubscriptionsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Customer\Subscriptions

--- a/Test/Unit/Controller/Webhook/IndexTest.php
+++ b/Test/Unit/Controller/Webhook/IndexTest.php
@@ -11,7 +11,7 @@ use Swarming\SubscribePro\Platform\Webhook\Processor as WebhookProcessor;
 use Swarming\SubscribePro\Model\Config\Advanced as AdvancedConfig;
 use Swarming\SubscribePro\Platform\Service\Webhook as WebhookService;
 
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Controller\Webhook\Index

--- a/Test/Unit/Gateway/Command/AbstractCommand.php
+++ b/Test/Unit/Gateway/Command/AbstractCommand.php
@@ -17,7 +17,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Store\Api\Data\StoreInterface;
 
-class AbstractCommand extends \PHPUnit_Framework_TestCase
+class AbstractCommand extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Payment\Gateway\Request\BuilderInterface

--- a/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
+++ b/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
@@ -8,7 +8,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Swarming\SubscribePro\Gateway\Command\CaptureStrategyCommand;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 
-class CaptureStrategyCommandTest extends \PHPUnit_Framework_TestCase
+class CaptureStrategyCommandTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Command\CaptureStrategyCommand

--- a/Test/Unit/Gateway/Config/ConfigProviderTest.php
+++ b/Test/Unit/Gateway/Config/ConfigProviderTest.php
@@ -12,7 +12,7 @@ use Swarming\SubscribePro\Model\Config\General as GeneralConfig;
 use Swarming\SubscribePro\Gateway\Config\Config as GatewayConfig;
 use Swarming\SubscribePro\Platform\Tool\Config as PlatformConfigTool;
 
-class ConfigProviderTest extends \PHPUnit_Framework_TestCase
+class ConfigProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Config\ConfigProvider

--- a/Test/Unit/Gateway/Config/ConfigTest.php
+++ b/Test/Unit/Gateway/Config/ConfigTest.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Swarming\SubscribePro\Gateway\Config\Config;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\Config\ScopeConfigInterface

--- a/Test/Unit/Gateway/Config/VaultConfigTest.php
+++ b/Test/Unit/Gateway/Config/VaultConfigTest.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Swarming\SubscribePro\Gateway\Config\VaultConfig;
 
-class VaultConfigTest extends \PHPUnit_Framework_TestCase
+class VaultConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Magento\Framework\App\Config\ScopeConfigInterface

--- a/Test/Unit/Gateway/Helper/SubjectReaderTest.php
+++ b/Test/Unit/Gateway/Helper/SubjectReaderTest.php
@@ -5,7 +5,7 @@ namespace Swarming\SubscribePro\Test\Unit\Gateway\Helper;
 use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 
-class SubjectReaderTest extends \PHPUnit_Framework_TestCase
+class SubjectReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/AddressDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/AddressDataBuilderTest.php
@@ -10,7 +10,7 @@ use Swarming\SubscribePro\Api\Data\AddressInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\AddressDataBuilder;
 
-class AddressDataReaderTest extends \PHPUnit_Framework_TestCase
+class AddressDataReaderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
@@ -9,7 +9,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\CaptureDataBuilder;
 
-class CaptureDataBuilderTest extends \PHPUnit_Framework_TestCase
+class CaptureDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/CustomerDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CustomerDataBuilderTest.php
@@ -9,7 +9,7 @@ use SubscribePro\Service\PaymentProfile\PaymentProfileInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\CustomerDataBuilder;
 
-class CustomerDataBuilderTest extends \PHPUnit_Framework_TestCase
+class CustomerDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
@@ -9,7 +9,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\OrderDataBuilder;
 
-class OrderDataBuilderTest extends \PHPUnit_Framework_TestCase
+class OrderDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/PaymentDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/PaymentDataBuilderTest.php
@@ -8,7 +8,7 @@ use Magento\Vault\Model\Ui\VaultConfigProvider;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\PaymentDataBuilder;
 
-class PaymentDataBuilderTest extends \PHPUnit_Framework_TestCase
+class PaymentDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/VaultDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/VaultDataBuilderTest.php
@@ -10,7 +10,7 @@ use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\VaultDataBuilder;
 use SubscribePro\Service\Transaction\TransactionInterface;
 
-class VaultDataBuilderTest extends \PHPUnit_Framework_TestCase
+class VaultDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Request/VoidDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/VoidDataBuilderTest.php
@@ -8,7 +8,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Request\VoidDataBuilder;
 
-class VoidDataBuilderTest extends \PHPUnit_Framework_TestCase
+class VoidDataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Gateway\Helper\SubjectReader

--- a/Test/Unit/Gateway/Response/CardDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/CardDetailsHandlerTest.php
@@ -10,7 +10,7 @@ use Swarming\SubscribePro\Gateway\Response\CardDetailsHandler;
 use Swarming\SubscribePro\Gateway\Config\Config as GatewayConfig;
 use Magento\Payment\Model\InfoInterface as PaymentInfoInterface;
 
-class CardDetailsHandlerTest extends \PHPUnit_Framework_TestCase
+class CardDetailsHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\CardDetailsHandler

--- a/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
@@ -8,7 +8,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Response\PaymentDetailsHandler;
 
-class PaymentDetailsHandlerTest extends \PHPUnit_Framework_TestCase
+class PaymentDetailsHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\PaymentDetailsHandler

--- a/Test/Unit/Gateway/Response/RefundHandlerTest.php
+++ b/Test/Unit/Gateway/Response/RefundHandlerTest.php
@@ -11,7 +11,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Response\RefundHandler;
 
-class RefundHandlerTest extends \PHPUnit_Framework_TestCase
+class RefundHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\RefundHandler

--- a/Test/Unit/Gateway/Response/TransactionIdHandlerTest.php
+++ b/Test/Unit/Gateway/Response/TransactionIdHandlerTest.php
@@ -9,7 +9,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Response\TransactionIdHandler;
 
-class TransactionIdHandlerTest extends \PHPUnit_Framework_TestCase
+class TransactionIdHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\TransactionIdHandler

--- a/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/VaultDetailsHandlerTest.php
@@ -15,7 +15,7 @@ use Swarming\SubscribePro\Gateway\Response\VaultDetailsHandler;
 use Swarming\SubscribePro\Helper\Vault as SubscribeProVaultHelper;
 use Swarming\SubscribePro\Gateway\Config\Config as GatewayConfig;
 
-class VaultDetailsHandlerTest extends \PHPUnit_Framework_TestCase
+class VaultDetailsHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\VaultDetailsHandler

--- a/Test/Unit/Gateway/Response/VoidHandlerTest.php
+++ b/Test/Unit/Gateway/Response/VoidHandlerTest.php
@@ -9,7 +9,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Response\VoidHandler;
 
-class VoidHandlerTest extends \PHPUnit_Framework_TestCase
+class VoidHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Response\VoidHandler

--- a/Test/Unit/Gateway/Validator/ResponseValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/ResponseValidatorTest.php
@@ -8,7 +8,7 @@ use SubscribePro\Service\Transaction\TransactionInterface;
 use Swarming\SubscribePro\Gateway\Helper\SubjectReader;
 use Swarming\SubscribePro\Gateway\Validator\ResponseValidator;
 
-class ResponseValidatorTest extends \PHPUnit_Framework_TestCase
+class ResponseValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Gateway\Validator\ResponseValidator

--- a/Test/Unit/Helper/OrderItemTest.php
+++ b/Test/Unit/Helper/OrderItemTest.php
@@ -11,7 +11,7 @@ use Swarming\SubscribePro\Helper\OrderItem as OrderItemHelper;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor;
 use Swarming\SubscribePro\Api\Data\ProductInterface as PlatformProductInterface;
 
-class OrderItemTest extends \PHPUnit_Framework_TestCase
+class OrderItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\OrderItem

--- a/Test/Unit/Helper/ProductOptionTest.php
+++ b/Test/Unit/Helper/ProductOptionTest.php
@@ -13,7 +13,7 @@ use Swarming\SubscribePro\Helper\ProductOption;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor;
 
-class ProductOptionTest extends \PHPUnit_Framework_TestCase
+class ProductOptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\ProductOption

--- a/Test/Unit/Helper/ProductTest.php
+++ b/Test/Unit/Helper/ProductTest.php
@@ -7,7 +7,7 @@ use Magento\Framework\Api\AttributeInterface;
 use Swarming\SubscribePro\Helper\Product as ProductHelper;
 use Swarming\SubscribePro\Ui\DataProvider\Product\Modifier\Subscription as SubscriptionModifier;
 
-class ProductTest extends \PHPUnit_Framework_TestCase
+class ProductTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\Product

--- a/Test/Unit/Helper/QuoteItemTest.php
+++ b/Test/Unit/Helper/QuoteItemTest.php
@@ -13,7 +13,7 @@ use Swarming\SubscribePro\Helper\QuoteItem;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor;
 use Swarming\SubscribePro\Api\Data\ProductInterface as PlatformProductInterface;
 
-class QuoteItemTest extends \PHPUnit_Framework_TestCase
+class QuoteItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\QuoteItem

--- a/Test/Unit/Helper/QuoteTest.php
+++ b/Test/Unit/Helper/QuoteTest.php
@@ -7,7 +7,7 @@ use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Swarming\SubscribePro\Helper\Quote;
 use Swarming\SubscribePro\Helper\QuoteItem as QuoteItemHelper;
 
-class QuoteTest extends \PHPUnit_Framework_TestCase
+class QuoteTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\Quote

--- a/Test/Unit/Helper/SubscriptionProductTest.php
+++ b/Test/Unit/Helper/SubscriptionProductTest.php
@@ -20,7 +20,7 @@ use Swarming\SubscribePro\Model\Subscription\OptionItem as SubscriptionOptionIte
 use Magento\Catalog\Helper\Product\Configuration\ConfigurationInterface as ProductConfigurationInterface;
 use Swarming\SubscribePro\Model\CatalogRule\InspectorInterface as CatalogRuleInspectorInterface;
 
-class SubscriptionProductTest extends \PHPUnit_Framework_TestCase
+class SubscriptionProductTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\SubscriptionProduct

--- a/Test/Unit/Helper/VaultTest.php
+++ b/Test/Unit/Helper/VaultTest.php
@@ -10,7 +10,7 @@ use Swarming\SubscribePro\Gateway\Config\ConfigProvider;
 use Swarming\SubscribePro\Helper\Vault;
 use Swarming\SubscribePro\Gateway\Config\Config as GatewayConfig;
 
-class VaultTest extends \PHPUnit_Framework_TestCase
+class VaultTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Helper\Vault

--- a/Test/Unit/Model/CatalogRule/Inspector/AbstractInspector.php
+++ b/Test/Unit/Model/CatalogRule/Inspector/AbstractInspector.php
@@ -11,7 +11,7 @@ use Magento\Catalog\Model\Product;
 use DateTime;
 use Magento\Catalog\Model\Product\Type\Price as PriceModel;
 
-abstract class AbstractInspector extends \PHPUnit_Framework_TestCase
+abstract class AbstractInspector extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Magento\Customer\Model\Session|\PHPUnit_Framework_MockObject_MockObject

--- a/Test/Unit/Model/CatalogRule/InspectorRepositoryTest.php
+++ b/Test/Unit/Model/CatalogRule/InspectorRepositoryTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Model\CatalogRule\InspectorRepository;
 use Magento\Framework\ObjectManagerInterface;
 use stdClass;
 
-class InspectorRepositoryTest extends \PHPUnit_Framework_TestCase
+class InspectorRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\CatalogRule\InspectorRepository

--- a/Test/Unit/Model/CatalogRule/InspectorTest.php
+++ b/Test/Unit/Model/CatalogRule/InspectorTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Model\CatalogRule\InspectorInterface;
 use Swarming\SubscribePro\Model\CatalogRule\InspectorRepository;
 use Magento\Catalog\Model\Product;
 
-class InspectorTest extends \PHPUnit_Framework_TestCase
+class InspectorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\CatalogRule\Inspector

--- a/Test/Unit/Model/Config/AdvancedTest.php
+++ b/Test/Unit/Model/Config/AdvancedTest.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Swarming\SubscribePro\Model\Config\Advanced;
 use Magento\Store\Model\ScopeInterface;
 
-class AdvancedTest extends \PHPUnit_Framework_TestCase
+class AdvancedTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Advanced

--- a/Test/Unit/Model/Config/GeneralTest.php
+++ b/Test/Unit/Model/Config/GeneralTest.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Swarming\SubscribePro\Model\Config\General;
 use Magento\Store\Model\ScopeInterface;
 
-class GeneralTest extends \PHPUnit_Framework_TestCase
+class GeneralTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\General

--- a/Test/Unit/Model/Config/PlatformTest.php
+++ b/Test/Unit/Model/Config/PlatformTest.php
@@ -7,7 +7,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Swarming\SubscribePro\Model\Config\Platform;
 use Magento\Store\Model\ScopeInterface;
 
-class PlatformTest extends \PHPUnit_Framework_TestCase
+class PlatformTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Platform

--- a/Test/Unit/Model/Config/Source/CartRuleCombineTest.php
+++ b/Test/Unit/Model/Config/Source/CartRuleCombineTest.php
@@ -4,7 +4,7 @@ namespace Swarming\SubscribePro\Test\Unit\Model\Config\Source;
 
 use Swarming\SubscribePro\Model\Config\Source\CartRuleCombine;
 
-class CartRuleCombineTest extends \PHPUnit_Framework_TestCase
+class CartRuleCombineTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Source\CartRuleCombine

--- a/Test/Unit/Model/Config/Source/CcTypeTest.php
+++ b/Test/Unit/Model/Config/Source/CcTypeTest.php
@@ -5,7 +5,7 @@ namespace Swarming\SubscribePro\Test\Unit\Model\Config\Source;
 use Swarming\SubscribePro\Model\Config\Source\CcType;
 use Magento\Payment\Model\Config as PaymentConfig;
 
-class CcTypeTest extends \PHPUnit_Framework_TestCase
+class CcTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Source\CcType

--- a/Test/Unit/Model/Config/Source/LogLevelsTest.php
+++ b/Test/Unit/Model/Config/Source/LogLevelsTest.php
@@ -4,7 +4,7 @@ namespace Swarming\SubscribePro\Test\Unit\Model\Config\Source;
 
 use Swarming\SubscribePro\Model\Config\Source\LogLevels;
 
-class LogLevelsTest extends \PHPUnit_Framework_TestCase
+class LogLevelsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Source\LogLevels

--- a/Test/Unit/Model/Config/Source/PaymentActionTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentActionTest.php
@@ -4,7 +4,7 @@ namespace Swarming\SubscribePro\Test\Unit\Model\Config\Source;
 
 use Swarming\SubscribePro\Model\Config\Source\PaymentAction;
 
-class PaymentActionTest extends \PHPUnit_Framework_TestCase
+class PaymentActionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\Source\PaymentAction

--- a/Test/Unit/Model/Config/SubscriptionDiscountTest.php
+++ b/Test/Unit/Model/Config/SubscriptionDiscountTest.php
@@ -6,7 +6,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Swarming\SubscribePro\Model\Config\SubscriptionDiscount;
 use Magento\Store\Model\ScopeInterface;
 
-class SubscriptionDiscountTest extends \PHPUnit_Framework_TestCase
+class SubscriptionDiscountTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\SubscriptionDiscount

--- a/Test/Unit/Model/Config/SubscriptionOptionsTest.php
+++ b/Test/Unit/Model/Config/SubscriptionOptionsTest.php
@@ -7,7 +7,7 @@ use Magento\Framework\Intl\DateTimeFactory;
 use Swarming\SubscribePro\Model\Config\SubscriptionOptions;
 use Magento\Store\Model\ScopeInterface;
 
-class SubscriptionOptionsTest extends \PHPUnit_Framework_TestCase
+class SubscriptionOptionsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Config\SubscriptionOptions

--- a/Test/Unit/Model/Quote/ItemSubscriptionDiscountTest.php
+++ b/Test/Unit/Model/Quote/ItemSubscriptionDiscountTest.php
@@ -15,7 +15,7 @@ use Swarming\SubscribePro\Model\Config\SubscriptionDiscount as SubscriptionDisco
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 
-class ItemSubscriptionDiscountTest extends \PHPUnit_Framework_TestCase
+class ItemSubscriptionDiscountTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Quote\ItemSubscriptionDiscount

--- a/Test/Unit/Model/Quote/QuoteItem/SubscriptionCreatorTest.php
+++ b/Test/Unit/Model/Quote/QuoteItem/SubscriptionCreatorTest.php
@@ -19,7 +19,7 @@ use Swarming\SubscribePro\Platform\Service\Subscription as SubscriptionService;
 use Swarming\SubscribePro\Helper\ProductOption as QuoteItemProductOption;
 use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 
-class SubscriptionCreatorTest extends \PHPUnit_Framework_TestCase
+class SubscriptionCreatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Quote\QuoteItem\SubscriptionCreator

--- a/Test/Unit/Model/Quote/SubscriptionCreatorTest.php
+++ b/Test/Unit/Model/Quote/SubscriptionCreatorTest.php
@@ -16,7 +16,7 @@ use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Swarming\SubscribePro\Platform\Manager\Customer as CustomerManager;
 use Swarming\SubscribePro\Model\Quote\QuoteItem\SubscriptionCreator as QuoteItemSubscriptionCreator;
 
-class SubscriptionCreatorTest extends \PHPUnit_Framework_TestCase
+class SubscriptionCreatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Quote\SubscriptionCreator

--- a/Test/Unit/Model/Quote/SubscriptionOption/OptionProcessorTest.php
+++ b/Test/Unit/Model/Quote/SubscriptionOption/OptionProcessorTest.php
@@ -13,7 +13,7 @@ use Swarming\SubscribePro\Api\Data\SubscriptionOptionInterfaceFactory;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor;
 use Magento\Framework\DataObject\Factory as DataObjectFactory;
 
-class OptionProcessorTest extends \PHPUnit_Framework_TestCase
+class OptionProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor

--- a/Test/Unit/Model/Quote/SubscriptionOption/UpdaterTest.php
+++ b/Test/Unit/Model/Quote/SubscriptionOption/UpdaterTest.php
@@ -12,7 +12,7 @@ use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater;
 
-class UpdaterTest extends \PHPUnit_Framework_TestCase
+class UpdaterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Quote\SubscriptionOption\Updater

--- a/Test/Unit/Model/Rule/ProductConditionTest.php
+++ b/Test/Unit/Model/Rule/ProductConditionTest.php
@@ -14,7 +14,7 @@ use \Magento\Quote\Model\Quote\Item;
 use \Swarming\SubscribePro\Helper\QuoteItem;
 use Swarming\SubscribePro\Model\Rule\Condition\Product as ProductCondition;
 
-class ProductConditionTest extends \PHPUnit_Framework_TestCase
+class ProductConditionTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetSubscriptionOptions()
     {

--- a/Test/Unit/Model/Subscription/OptionItemManagerTest.php
+++ b/Test/Unit/Model/Subscription/OptionItemManagerTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\DataObject\Factory as DataObjectFactory;
 use Swarming\SubscribePro\Model\Subscription\OptionItem as SubscriptionOptionItem;
 use Magento\Catalog\Model\Product\Type\AbstractType as ProductTypeInstance;
 
-class OptionItemManagerTest extends \PHPUnit_Framework_TestCase
+class OptionItemManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Subscription\OptionItemManager

--- a/Test/Unit/Model/Subscription/OptionItemTest.php
+++ b/Test/Unit/Model/Subscription/OptionItemTest.php
@@ -6,7 +6,7 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface;
 use Swarming\SubscribePro\Model\Subscription\OptionItem;
 
-class OptionItemTest extends \PHPUnit_Framework_TestCase
+class OptionItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Subscription\OptionItem

--- a/Test/Unit/Model/Vault/FormTest.php
+++ b/Test/Unit/Model/Vault/FormTest.php
@@ -15,7 +15,7 @@ use Swarming\SubscribePro\Model\Vault\Validator as VaultValidator;
 use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface;
 use Swarming\SubscribePro\Helper\DebugLogger;
 
-class FormTest extends \PHPUnit_Framework_TestCase
+class FormTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Vault\Form

--- a/Test/Unit/Model/Vault/ValidatorTest.php
+++ b/Test/Unit/Model/Vault/ValidatorTest.php
@@ -9,7 +9,7 @@ use Swarming\SubscribePro\Api\Data\AddressInterface;
 use Swarming\SubscribePro\Model\Vault\Validator;
 use Magento\Directory\Helper\Data as DirectoryDataHelper;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Model\Vault\Validator

--- a/Test/Unit/Observer/Catalog/ProductSaveAfterTest.php
+++ b/Test/Unit/Observer/Catalog/ProductSaveAfterTest.php
@@ -16,7 +16,7 @@ use Swarming\SubscribePro\Model\Config\General as GeneralConfig;
 use Swarming\SubscribePro\Platform\Manager\Product as ProductManager;
 use Swarming\SubscribePro\Helper\Product as ProductHelper;
 
-class ProductSaveAfterTest extends \PHPUnit_Framework_TestCase
+class ProductSaveAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Catalog\ProductSaveAfter

--- a/Test/Unit/Observer/Checkout/IsAllowedGuestTest.php
+++ b/Test/Unit/Observer/Checkout/IsAllowedGuestTest.php
@@ -11,7 +11,7 @@ use Swarming\SubscribePro\Observer\Checkout\IsAllowedGuest;
 use Swarming\SubscribePro\Model\Config\General as GeneralConfig;
 use Swarming\SubscribePro\Helper\Quote as QuoteHelper;
 
-class IsAllowedGuestTest extends \PHPUnit_Framework_TestCase
+class IsAllowedGuestTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Checkout\IsAllowedGuest

--- a/Test/Unit/Observer/Checkout/SubmitAllAfterTest.php
+++ b/Test/Unit/Observer/Checkout/SubmitAllAfterTest.php
@@ -15,7 +15,7 @@ use Swarming\SubscribePro\Observer\Checkout\SubmitAllAfter;
 use Swarming\SubscribePro\Model\Config\General as GeneralConfig;
 use Swarming\SubscribePro\Gateway\Config\ConfigProvider;
 
-class SubmitAllAfterTest extends \PHPUnit_Framework_TestCase
+class SubmitAllAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Checkout\SubmitAllAfter

--- a/Test/Unit/Observer/CheckoutCart/AddProductToCartAfterTest.php
+++ b/Test/Unit/Observer/CheckoutCart/AddProductToCartAfterTest.php
@@ -20,7 +20,7 @@ use Swarming\SubscribePro\Helper\Product as ProductHelper;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Swarming\SubscribePro\Helper\QuoteItem as QuoteItemHelper;
 
-class AddProductToCartAfterTest extends \PHPUnit_Framework_TestCase
+class AddProductToCartAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\CheckoutCart\AddProductToCartAfter

--- a/Test/Unit/Observer/CheckoutCart/CartUpdateItemsAfterTest.php
+++ b/Test/Unit/Observer/CheckoutCart/CartUpdateItemsAfterTest.php
@@ -23,7 +23,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Swarming\SubscribePro\Helper\Product as ProductHelper;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 
-class CartUpdateItemsAfterTest extends \PHPUnit_Framework_TestCase
+class CartUpdateItemsAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\CheckoutCart\CartUpdateItemsAfter

--- a/Test/Unit/Observer/CheckoutCart/UpdateProductAfterTest.php
+++ b/Test/Unit/Observer/CheckoutCart/UpdateProductAfterTest.php
@@ -22,7 +22,7 @@ use Swarming\SubscribePro\Helper\Product as ProductHelper;
 use Swarming\SubscribePro\Helper\QuoteItem as QuoteItemHelper;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 
-class UpdateProductAfterTest extends \PHPUnit_Framework_TestCase
+class UpdateProductAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\CheckoutCart\UpdateProductAfter

--- a/Test/Unit/Observer/Config/CustomerConfigSaveAfterTest.php
+++ b/Test/Unit/Observer/Config/CustomerConfigSaveAfterTest.php
@@ -11,7 +11,7 @@ use Magento\Store\Model\ScopeInterface;
 use Magento\Customer\Model\Config\Share;
 use Magento\Config\Model\Config\Factory as ConfigFactory;
 
-class CustomerConfigSaveAfterTest extends \PHPUnit_Framework_TestCase
+class CustomerConfigSaveAfterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Config\CustomerConfigSaveAfter

--- a/Test/Unit/Observer/Payment/AvailabilityTest.php
+++ b/Test/Unit/Observer/Payment/AvailabilityTest.php
@@ -12,7 +12,7 @@ use Swarming\SubscribePro\Observer\Payment\Availability as PaymentAvailability;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Swarming\SubscribePro\Helper\Quote as QuoteHelper;
 
-class Availability extends \PHPUnit_Framework_TestCase
+class Availability extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Payment\Availability

--- a/Test/Unit/Observer/Payment/DataAssignerTest.php
+++ b/Test/Unit/Observer/Payment/DataAssignerTest.php
@@ -11,7 +11,7 @@ use Swarming\SubscribePro\Gateway\Request\PaymentDataBuilder;
 use Swarming\SubscribePro\Observer\Payment\DataAssigner as PaymentDataAssigner;
 use Magento\Payment\Model\InfoInterface as PaymentInfoInterface;
 
-class DataAssignerTest extends \PHPUnit_Framework_TestCase
+class DataAssignerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Payment\DataAssigner

--- a/Test/Unit/Observer/Payment/TokenAssignerTest.php
+++ b/Test/Unit/Observer/Payment/TokenAssignerTest.php
@@ -19,7 +19,7 @@ use Magento\Quote\Model\Quote\Payment as QuotePayment;
 use Swarming\SubscribePro\Observer\Payment\TokenAssigner as PaymentTokenAssigner;
 use Magento\Payment\Model\InfoInterface as PaymentInfoInterface;
 
-class TokenAssignerTest extends \PHPUnit_Framework_TestCase
+class TokenAssignerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Observer\Payment\TokenAssigner

--- a/Test/Unit/Platform/Manager/AddressTest.php
+++ b/Test/Unit/Platform/Manager/AddressTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Platform\Manager\Address;
 use Swarming\SubscribePro\Platform\Service\Address as AddressService;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Manager\Address

--- a/Test/Unit/Platform/Manager/CustomerTest.php
+++ b/Test/Unit/Platform/Manager/CustomerTest.php
@@ -8,7 +8,7 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Swarming\SubscribePro\Platform\Manager\Customer;
 use Swarming\SubscribePro\Platform\Service\Customer as CustomerService;
 
-class CustomerTest extends \PHPUnit_Framework_TestCase
+class CustomerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Manager\Customer

--- a/Test/Unit/Platform/Manager/ProductTest.php
+++ b/Test/Unit/Platform/Manager/ProductTest.php
@@ -8,7 +8,7 @@ use Swarming\SubscribePro\Platform\Service\Product as ProductService;
 use Swarming\SubscribePro\Platform\Storage\Product as ProductStorage;
 use Magento\Catalog\Api\Data\ProductInterface;
 
-class ProductTest extends \PHPUnit_Framework_TestCase
+class ProductTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Manager\Product

--- a/Test/Unit/Platform/PlatformTest.php
+++ b/Test/Unit/Platform/PlatformTest.php
@@ -9,7 +9,7 @@ use Swarming\SubscribePro\Platform\Platform;
 use Swarming\SubscribePro\Model\Config\Platform as PlatformConfig;
 use SubscribePro\Sdk as SubscribeProSdk;
 
-class PlatformTest extends \PHPUnit_Framework_TestCase
+class PlatformTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Platform

--- a/Test/Unit/Platform/Service/AbstractService.php
+++ b/Test/Unit/Platform/Service/AbstractService.php
@@ -4,7 +4,7 @@ namespace Swarming\SubscribePro\Test\Unit\Platform\Service;
 
 use Swarming\SubscribePro\Platform\Platform;
 
-class AbstractService extends \PHPUnit_Framework_TestCase
+class AbstractService extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\Swarming\SubscribePro\Platform\Platform

--- a/Test/Unit/Platform/Storage/ConfigTest.php
+++ b/Test/Unit/Platform/Storage/ConfigTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\Cache\FrontendInterface as CacheFrontendInterface;
 use Magento\Framework\App\Cache\StateInterface as CacheStateInterface;
 use Swarming\SubscribePro\Model\Config\Advanced as CacheConfig;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Storage\Config

--- a/Test/Unit/Platform/Storage/ProductTest.php
+++ b/Test/Unit/Platform/Storage/ProductTest.php
@@ -10,7 +10,7 @@ use Magento\Framework\Cache\FrontendInterface as CacheFrontendInterface;
 use Magento\Framework\App\Cache\StateInterface as CacheStateInterface;
 use Swarming\SubscribePro\Model\Config\Advanced as CacheConfig;
 
-class ProductTest extends \PHPUnit_Framework_TestCase
+class ProductTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Storage\Product

--- a/Test/Unit/Platform/Tool/ConfigTest.php
+++ b/Test/Unit/Platform/Tool/ConfigTest.php
@@ -7,7 +7,7 @@ use SubscribePro\Tools\Config as ConfigTool;
 use Swarming\SubscribePro\Platform\Storage\Config as ConfigStorage;
 use Swarming\SubscribePro\Platform\Tool\Config;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Tool\Config

--- a/Test/Unit/Platform/Webhook/Handler/PaymentProfile/CreateHandlerTest.php
+++ b/Test/Unit/Platform/Webhook/Handler/PaymentProfile/CreateHandlerTest.php
@@ -15,7 +15,7 @@ use Swarming\SubscribePro\Helper\Vault as VaultHelper;
 use Magento\Vault\Model\CreditCardTokenFactory;
 use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface;
 
-class CreateHandlerTest extends \PHPUnit_Framework_TestCase
+class CreateHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Webhook\Handler\PaymentProfile\CreateHandler

--- a/Test/Unit/Platform/Webhook/Handler/PaymentProfile/RedactHandlerTest.php
+++ b/Test/Unit/Platform/Webhook/Handler/PaymentProfile/RedactHandlerTest.php
@@ -13,7 +13,7 @@ use Swarming\SubscribePro\Gateway\Config\ConfigProvider;
 use Swarming\SubscribePro\Platform\Webhook\Handler\PaymentProfile\RedactHandler;
 use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface;
 
-class RedactHandlerTest extends \PHPUnit_Framework_TestCase
+class RedactHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Webhook\Handler\PaymentProfile\RedactHandler

--- a/Test/Unit/Platform/Webhook/Handler/PaymentProfile/UpdateHandlerTest.php
+++ b/Test/Unit/Platform/Webhook/Handler/PaymentProfile/UpdateHandlerTest.php
@@ -15,7 +15,7 @@ use SubscribePro\Service\Customer\CustomerInterface as PlatformCustomerInterface
 use Swarming\SubscribePro\Platform\Service\PaymentProfile as PaymentProfileService;
 use Swarming\SubscribePro\Helper\Vault as VaultHelper;
 
-class UpdateHandlerTest extends \PHPUnit_Framework_TestCase
+class UpdateHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Webhook\Handler\PaymentProfile\UpdateHandler

--- a/Test/Unit/Platform/Webhook/HandlerPoolTest.php
+++ b/Test/Unit/Platform/Webhook/HandlerPoolTest.php
@@ -5,7 +5,7 @@ namespace Swarming\SubscribePro\Test\Unit\Platform\Webhook;
 use Swarming\SubscribePro\Platform\Webhook\HandlerInterface;
 use Swarming\SubscribePro\Platform\Webhook\HandlerPool;
 
-class HandlerPoolTest extends \PHPUnit_Framework_TestCase
+class HandlerPoolTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param array $handlers

--- a/Test/Unit/Platform/Webhook/ProcessorTest.php
+++ b/Test/Unit/Platform/Webhook/ProcessorTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Platform\Webhook\HandlerPool;
 use Swarming\SubscribePro\Platform\Webhook\Processor;
 use SubscribePro\Service\Webhook\EventInterface as WebhookEventInterface;
 
-class ProcessorTest extends \PHPUnit_Framework_TestCase
+class ProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Webhook\Processor

--- a/Test/Unit/Plugin/AdminOrder/CreateTest.php
+++ b/Test/Unit/Plugin/AdminOrder/CreateTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Helper\OrderItem as OrderItemHelper;
 use Magento\Sales\Model\AdminOrder\Create as AdminOrderCreate;
 use Magento\Sales\Model\Order\Item as OrderItem;
 
-class CreateTest extends \PHPUnit_Framework_TestCase
+class CreateTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\AdminOrder\Create

--- a/Test/Unit/Plugin/Checkout/CartTest.php
+++ b/Test/Unit/Plugin/Checkout/CartTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Helper\OrderItem as OrderItemHelper;
 use Magento\Checkout\Model\Cart as CheckoutCart;
 use Magento\Sales\Model\Order\Item as OrderItem;
 
-class CartTest extends \PHPUnit_Framework_TestCase
+class CartTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Checkout\Cart

--- a/Test/Unit/Plugin/Customer/CustomerRepositoryTest.php
+++ b/Test/Unit/Plugin/Customer/CustomerRepositoryTest.php
@@ -11,7 +11,7 @@ use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
 
-class CustomerRepositoryTest extends \PHPUnit_Framework_TestCase
+class CustomerRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Platform\Manager\Customer|\PHPUnit_Framework_MockObject_MockObject

--- a/Test/Unit/Plugin/GroupedProduct/TypeGroupedTest.php
+++ b/Test/Unit/Plugin/GroupedProduct/TypeGroupedTest.php
@@ -7,7 +7,7 @@ use Magento\GroupedProduct\Model\Product\Type\Grouped as TypeGroupedSubject;
 use Magento\Catalog\Model\ResourceModel\Product\Link\Product\Collection as ProductCollection;
 use Swarming\SubscribePro\Ui\DataProvider\Product\Modifier\Subscription as SubscriptionModifier;
 
-class TypeGroupedTest extends \PHPUnit_Framework_TestCase
+class TypeGroupedTest extends \PHPUnit\Framework\TestCase
 {
     public function testAroundCompareOptionsIfSubjectResultIsFalse()
     {

--- a/Test/Unit/Plugin/Product/ConfigurationTest.php
+++ b/Test/Unit/Plugin/Product/ConfigurationTest.php
@@ -10,7 +10,7 @@ use Magento\Catalog\Model\Product\Configuration\Item\ItemInterface as Configurat
 use Magento\Catalog\Helper\Product\Configuration as ProductConfiguration;
 use SubscribePro\Service\Product\ProductInterface as PlatformProductInterface;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Product\Configuration

--- a/Test/Unit/Plugin/Product/SubscriptionTest.php
+++ b/Test/Unit/Plugin/Product/SubscriptionTest.php
@@ -8,7 +8,7 @@ use Swarming\SubscribePro\Model\Config\SubscriptionDiscount as SubscriptionDisco
 use Swarming\SubscribePro\Helper\Product as ProductHelper;
 use Magento\Catalog\Block\Product\View as ProductView;
 
-class SubscriptionTest extends \PHPUnit_Framework_TestCase
+class SubscriptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Product\Subscription

--- a/Test/Unit/Plugin/Quote/CartItemOptionProcessorTest.php
+++ b/Test/Unit/Plugin/Quote/CartItemOptionProcessorTest.php
@@ -8,7 +8,7 @@ use Swarming\SubscribePro\Plugin\Quote\CartItemOptionsProcessor;
 use Swarming\SubscribePro\Model\Quote\SubscriptionOption\OptionProcessor as SubscriptionOptionProcessor;
 use Magento\Quote\Model\Quote\Item\CartItemOptionsProcessor as QuoteCartItemOptionsProcessor;
 
-class CartItemOptionsProcessorTest extends \PHPUnit_Framework_TestCase
+class CartItemOptionsProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Quote\CartItemOptionsProcessor

--- a/Test/Unit/Plugin/Quote/ItemTest.php
+++ b/Test/Unit/Plugin/Quote/ItemTest.php
@@ -9,7 +9,7 @@ use Swarming\SubscribePro\Helper\QuoteItem as QuoteItemHelper;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Magento\Quote\Model\Quote\Item\Option as QuoteItemOptionMock;
 
-class ItemTest extends \PHPUnit_Framework_TestCase
+class ItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Quote\Item

--- a/Test/Unit/Plugin/Quote/ToOrderItemTest.php
+++ b/Test/Unit/Plugin/Quote/ToOrderItemTest.php
@@ -8,7 +8,7 @@ use Swarming\SubscribePro\Helper\OrderItem as OrderItemHelper;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Quote\Model\Quote\Item\ToOrderItem as QuoteToOrderItem;
 
-class ToOrderItemTest extends \PHPUnit_Framework_TestCase
+class ToOrderItemTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Quote\ToOrderItem

--- a/Test/Unit/Plugin/SalesRule/ValidatorTest.php
+++ b/Test/Unit/Plugin/SalesRule/ValidatorTest.php
@@ -14,7 +14,7 @@ use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Swarming\SubscribePro\Model\CatalogRule\InspectorInterface as CatalogRuleInspectorInterface;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\SalesRule\Validator

--- a/Test/Unit/Plugin/Vault/TokenRepositoryTest.php
+++ b/Test/Unit/Plugin/Vault/TokenRepositoryTest.php
@@ -11,7 +11,7 @@ use Swarming\SubscribePro\Plugin\Vault\TokenRepository;
 use Swarming\SubscribePro\Platform\Service\PaymentProfile as PaymentProfileService;
 use SubscribePro\Service\PaymentProfile\PaymentProfileInterface;
 
-class TokenRepositoryTest extends \PHPUnit_Framework_TestCase
+class TokenRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Plugin\Vault\TokenRepository

--- a/Test/Unit/Service/AddressManagementTest.php
+++ b/Test/Unit/Service/AddressManagementTest.php
@@ -12,7 +12,7 @@ use Swarming\SubscribePro\Service\AddressManagement;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Magento\Customer\Block\Address\Renderer\RendererInterface as AddressRendererInterface;
 
-class AddressManagementTest extends \PHPUnit_Framework_TestCase
+class AddressManagementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Service\AddressManagement

--- a/Test/Unit/Service/PaymentTokenManagementTest.php
+++ b/Test/Unit/Service/PaymentTokenManagementTest.php
@@ -13,7 +13,7 @@ use Magento\Vault\Api\Data\PaymentTokenSearchResultsInterface;
 use Magento\Vault\Api\PaymentTokenRepositoryInterface;
 use Swarming\SubscribePro\Service\PaymentTokenManagement;
 
-class PaymentTokenManagementTest extends \PHPUnit_Framework_TestCase
+class PaymentTokenManagementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Service\PaymentTokenManagement

--- a/Test/Unit/Service/SubscriptionManagementTest.php
+++ b/Test/Unit/Service/SubscriptionManagementTest.php
@@ -23,7 +23,7 @@ use Swarming\SubscribePro\Helper\SubscriptionProduct as SubscriptionProductsHelp
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
 use Swarming\SubscribePro\Model\Config\SubscriptionOptions as SubscriptionOptionsConfig;
 
-class SubscriptionManagementTest extends \PHPUnit_Framework_TestCase
+class SubscriptionManagementTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Service\SubscriptionManagement

--- a/Test/Unit/Ui/ComponentProvider/AddressAttributesTest.php
+++ b/Test/Unit/Ui/ComponentProvider/AddressAttributesTest.php
@@ -9,7 +9,7 @@ use Magento\Ui\Component\Form\AttributeMapper;
 use Swarming\SubscribePro\Ui\ComponentProvider\AddressAttributes;
 use Magento\Customer\Model\Options as CustomerOptions;
 
-class AddressAttributesTest extends \PHPUnit_Framework_TestCase
+class AddressAttributesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\ComponentProvider\AddressAttributes

--- a/Test/Unit/Ui/ComponentProvider/VaultTokenTest.php
+++ b/Test/Unit/Ui/ComponentProvider/VaultTokenTest.php
@@ -9,7 +9,7 @@ use Magento\Vault\Model\Ui\TokenUiComponentProviderInterface;
 use Swarming\SubscribePro\Gateway\Config\ConfigProvider;
 use Swarming\SubscribePro\Ui\ComponentProvider\VaultToken;
 
-class VaultTokenTest extends \PHPUnit_Framework_TestCase
+class VaultTokenTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\ComponentProvider\VaultToken

--- a/Test/Unit/Ui/ConfigProvider/CheckoutTest.php
+++ b/Test/Unit/Ui/ConfigProvider/CheckoutTest.php
@@ -5,7 +5,7 @@ namespace Swarming\SubscribePro\Test\Unit\Ui\ConfigProvider;
 use Swarming\SubscribePro\Ui\ConfigProvider\Checkout;
 use Swarming\SubscribePro\Gateway\Config\ConfigProvider as GatewayConfigProvider;
 
-class CheckoutTest extends \PHPUnit_Framework_TestCase
+class CheckoutTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\ConfigProvider\Checkout

--- a/Test/Unit/Ui/ConfigProvider/PriceConfigTest.php
+++ b/Test/Unit/Ui/ConfigProvider/PriceConfigTest.php
@@ -7,7 +7,7 @@ use Swarming\SubscribePro\Model\Config\SubscriptionDiscount as SubscriptionDisco
 use Magento\Tax\Model\Config as TaxConfig;
 use Magento\Framework\Locale\FormatInterface as LocaleFormatInterface;
 
-class PriceConfigTest extends \PHPUnit_Framework_TestCase
+class PriceConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\ConfigProvider\PriceConfig

--- a/Test/Unit/Ui/ConfigProvider/SubscriptionConfigTest.php
+++ b/Test/Unit/Ui/ConfigProvider/SubscriptionConfigTest.php
@@ -8,7 +8,7 @@ use Swarming\SubscribePro\Model\Config\SubscriptionOptions;
 use Swarming\SubscribePro\Ui\ConfigProvider\SubscriptionConfig;
 use Swarming\SubscribePro\Model\Config\SubscriptionOptions as SubscriptionOptionsConfig;
 
-class SubscriptionConfigTest extends \PHPUnit_Framework_TestCase
+class SubscriptionConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\ConfigProvider\SubscriptionConfig

--- a/Test/Unit/Ui/DataProvider/Product/Modifier/SubscriptionTest.php
+++ b/Test/Unit/Ui/DataProvider/Product/Modifier/SubscriptionTest.php
@@ -9,7 +9,7 @@ use Magento\Framework\Stdlib\ArrayManager;
 use Swarming\SubscribePro\Ui\DataProvider\Product\Modifier\Subscription;
 use Magento\Ui\Component\Form;
 
-class SubscriptionTest extends \PHPUnit_Framework_TestCase
+class SubscriptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Swarming\SubscribePro\Ui\DataProvider\Product\Modifier\Subscription


### PR DESCRIPTION
Newer versions of PHPUnit use \PHPUnit\Framework\TestCase instead of \PHPUnit_Framework_TestCase.

This doesn't make all tests pass but makes it possible to at least run the tests and see most of them passing. Still would need to go back through and fix any remaining issues with various tests.