### PR TITLE
[#155189997] Don't show Subscribe Pro Vault payment method for free orders

### DIFF
--- a/Observer/Payment/Availability.php
+++ b/Observer/Payment/Availability.php
@@ -54,7 +54,12 @@ class Availability implements ObserverInterface
         $isAvailable = $result->getData('is_available');
         $isActiveNonSubscription = $methodInstance->getConfigData(Config::KEY_ACTIVE_NON_SUBSCRIPTION);
 
-        if ($this->quoteHelper->hasSubscription($quote)) {
+        $grandTotal = $quote->getGrandTotal();
+
+        // Only show the SP payment method when a subscription is in the cart
+        // and it's not a free order. For free orders we will use the 'free'
+        // payment method available in magento.
+        if ($this->quoteHelper->hasSubscription($quote) && $grandTotal > 0) {
             $isAvailable = ConfigProvider::CODE == $methodCode && $isAvailable;
         } else if (ConfigProvider::CODE == $methodCode && !$isActiveNonSubscription) {
             $isAvailable = false;


### PR DESCRIPTION
This will require platform changes so that the 'free' payment method is sent instead of the subscribe_pro payment method when 'free' is available, based on the "Free Payment Method Mode" platform configuration setting.