### PR TITLE
Fix adding bundle subscription products to the cart in Magento 2.2

### DIFF
--- a/Model/CatalogRule/Inspector/BundleProduct.php
+++ b/Model/CatalogRule/Inspector/BundleProduct.php
@@ -45,7 +45,7 @@ class BundleProduct extends DefaultInspector implements InspectorInterface
         /** @var \Magento\Catalog\Model\Product\Configuration\Item\Option $customOption */
         $customOption = $product->getCustomOption('bundle_selection_ids');
         return $customOption
-            ? unserialize($customOption->getValue())
+            ? json_decode($customOption->getValue())
             : [];
     }
 }

--- a/Test/Unit/Model/CatalogRule/Inspector/BundleProductTest.php
+++ b/Test/Unit/Model/CatalogRule/Inspector/BundleProductTest.php
@@ -164,7 +164,7 @@ class BundleProductTest extends AbstractInspector
             ->getMock();
         $option->expects($this->atLeastOnce())
             ->method('getValue')
-            ->willReturn(serialize($selectionIds));
+            ->willReturn(json_encode($selectionIds));
 
         $sections = [];
         foreach (array_keys($selectionIds) as $selectionKey) {
@@ -266,7 +266,7 @@ class BundleProductTest extends AbstractInspector
             ->getMock();
         $option->expects($this->atLeastOnce())
             ->method('getValue')
-            ->willReturn(serialize([$selection1Id, $selection2Id]));
+            ->willReturn(json_encode([$selection1Id, $selection2Id]));
 
         $product = $this->prepareProductMock($parentPrice, $parentProductId, $customerGroupId, $storeId);
         $product->expects($this->exactly(2))


### PR DESCRIPTION
After this change, below are all instances of serialize/unserialize in our extension. In these cases we are serializing into cache and then unserializing from cache. In the cases that have caused issues (i.e. buyRequests and product options for bundles) the data was being json_encoded by Magento and then we were trying to unserialize.

```
./Test/Unit/Platform/Storage/ProductTest.php:            ->willReturn(serialize($platformProductMock));
./Test/Unit/Platform/Storage/ConfigTest.php:            ->willReturn(serialize($configData));
./Test/Unit/Platform/Storage/ConfigTest.php:                serialize($config),
./Test/Unit/Platform/Storage/ConfigTest.php:                serialize($config),
./Platform/Storage/Config.php:        $config = unserialize($configData);
./Platform/Storage/Config.php:        return $this->cache->save(serialize($config), $cacheKey, [], $lifeTime);
./Platform/Storage/Product.php:        $platformProduct = unserialize($platformProductData);
./Platform/Storage/Product.php:        $this->cache->save(serialize($platformProduct), $cacheKey, [], $lifeTime);
./Platform/Storage/Product.php:        return self::PRODUCT_CACHE_KEY . '_' . md5(serialize([$sku, $websiteCode]));
```
