### PR TITLE
[#156374630] Make subscription widget show up on admin ordering items grid in Magento 2.2

### DIFF
--- a/view/adminhtml/layout/sales_order_create_index.xml
+++ b/view/adminhtml/layout/sales_order_create_index.xml
@@ -11,6 +11,7 @@
                 <argument name="template" xsi:type="string">Magento_Vault::form/vault.phtml</argument>
             </action>
         </referenceBlock>
+        <referenceBlock name="items_grid" template="Swarming_SubscribePro::order/create/items/grid.phtml"/>
         <referenceBlock name="content">
             <block class="Swarming\SubscribePro\Block\Adminhtml\System\Config\Config" name="subscribe_pro_script" template="Swarming_SubscribePro::payment/script.phtml" after="billing_method"/>
         </referenceBlock>

--- a/view/adminhtml/layout/sales_order_create_load_block_items.xml
+++ b/view/adminhtml/layout/sales_order_create_load_block_items.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="items_grid" template="Swarming_SubscribePro::order/create/items/grid.phtml"/>
+    </body>
+</page>


### PR DESCRIPTION
The first edit in the existing layout file allows our block template to be used when the admin ordering page is initially loaded (or refreshed). The layout file I added allows our block template to be used when templates are reloaded via AJAX while adding products to the order.