### PR TITLE
[#159209807] Add trial product support

### DIFF
--- a/Observer/CheckoutCart/CheckoutCartAbstract.php
+++ b/Observer/CheckoutCart/CheckoutCartAbstract.php
@@ -101,6 +101,11 @@ abstract class CheckoutCartAbstract implements ObserverInterface
             return;
         }
 
+        if ($platformProduct->getIsTrialProduct()) {
+            $quoteItem->setOriginalCustomPrice($platformProduct->getTrialPrice());
+            $quoteItem->setCustomPrice($platformProduct->getTrialPrice());
+        }
+
         $warnings = $this->subscriptionOptionUpdater->update(
             $quoteItem,
             $platformProduct,

--- a/Observer/CheckoutCart/CheckoutCartAbstract.php
+++ b/Observer/CheckoutCart/CheckoutCartAbstract.php
@@ -8,6 +8,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Swarming\SubscribePro\Api\Data\SubscriptionOptionInterface;
+use SubscribePro\Service\Product\ProductInterface as SubscribeProProductInterface;
 
 abstract class CheckoutCartAbstract implements ObserverInterface
 {
@@ -102,6 +103,7 @@ abstract class CheckoutCartAbstract implements ObserverInterface
         }
 
         if ($platformProduct->getIsTrialProduct()) {
+            $quoteItemParams[SubscriptionOptionInterface::OPTION] = SubscribeProProductInterface::SO_SUBSCRIPTION;
             $quoteItem->setOriginalCustomPrice($platformProduct->getTrialPrice());
             $quoteItem->setCustomPrice($platformProduct->getTrialPrice());
         }

--- a/view/frontend/web/js/model/product/price.js
+++ b/view/frontend/web/js/model/product/price.js
@@ -15,6 +15,7 @@ define(
 
                 productPrice.discount = product.discount;
                 productPrice.is_discount_percentage = product.is_discount_percentage;
+                productPrice.trialPrice = product.trial_price;
 
                 productPrice.price = ko.observable(product.price);
                 productPrice.hasSpecialPrice = ko.observable(product.is_catalog_rule_applied);
@@ -89,6 +90,10 @@ define(
 
                 productPrice.setFrontendPrice = function(frontendPrice) {
                     productPrice.price(getPriceFromFrontendPrice(frontendPrice));
+                };
+
+                productPrice.getTrialPrice = function() {
+                    return getFormattedPrice(productPrice.trialPrice);
                 };
 
                 function getFormattedPrice(price) {

--- a/view/frontend/web/js/view/cart/subscription.js
+++ b/view/frontend/web/js/view/cart/subscription.js
@@ -86,6 +86,10 @@ define(
                 return this.product.default_subscription_option == optionValue;
             },
 
+            isTrialMode: function() {
+                return this.product.is_trial_product;
+            },
+
             onQtyFieldChanged: function () {
                 if (this.subscriptionOptionValue() == this.oneTimePurchaseOption) {
                     return;

--- a/view/frontend/web/template/cart/subscription.html
+++ b/view/frontend/web/template/cart/subscription.html
@@ -1,12 +1,12 @@
 <!-- ko if: isProductLoaded() -->
     <div class="fieldset">
-        <!-- ko if: isSubscriptionMode(subscriptionOnlyMode)  -->
+        <!-- ko if: isSubscriptionMode(subscriptionOnlyMode) || isTrialMode()  -->
               <input type="hidden"
                      data-bind="
                      value: subscriptionOption,
                      attr: {name: 'cart['+quoteItemId+'][subscription_option][option]'}">
         <!-- /ko -->
-        <!-- ko if: isSubscriptionMode(subscriptionAndOneTimePurchaseMode) -->
+        <!-- ko if: isSubscriptionMode(subscriptionAndOneTimePurchaseMode) && !isTrialMode() -->
             <p>
                 <!-- ko i18n: 'Would you like to receive regular shipments of this item?' --><!-- /ko -->
             </p>

--- a/view/frontend/web/template/cart/subscription.html
+++ b/view/frontend/web/template/cart/subscription.html
@@ -5,6 +5,11 @@
                      data-bind="
                      value: subscriptionOption,
                      attr: {name: 'cart['+quoteItemId+'][subscription_option][option]'}">
+            <!-- ko if: isTrialMode() -->
+                <div class="field">
+                    <!-- ko i18n: 'Trial Subscription' --><!-- /ko -->
+                </div>
+            <!-- /ko -->
         <!-- /ko -->
         <!-- ko if: isSubscriptionMode(subscriptionAndOneTimePurchaseMode) && !isTrialMode() -->
             <p>

--- a/view/frontend/web/template/product/subscription.html
+++ b/view/frontend/web/template/product/subscription.html
@@ -1,10 +1,18 @@
 <!-- ko if: isProductLoaded() -->
     <div class="fieldset">
-        <!-- ko if: isSubscriptionMode(subscriptionOnlyMode)  -->
+        <!-- ko if: isSubscriptionMode(subscriptionOnlyMode) || isTrialMode()  -->
             <input type="hidden" name="subscription_option[option]" data-bind="value: subscriptionOption">
-            <!-- ko i18n: productPrice.priceWithDiscountText --><!-- /ko -->
+            <!-- ko if: isTrialMode() -->
+                <div class="field">
+                    <!-- ko text: productPrice.getTrialPrice() --><!-- /ko -->
+                    <!-- ko i18n: 'trial price' --><!-- /ko -->
+                </div>
+            <!-- /ko -->
+            <!-- ko ifnot: isTrialMode() -->
+                <!-- ko i18n: productPrice.priceWithDiscountText --><!-- /ko -->
+            <!-- /ko -->
         <!-- /ko -->
-        <!-- ko if: isSubscriptionMode(subscriptionAndOneTimePurchaseMode) -->
+        <!-- ko if: isSubscriptionMode(subscriptionAndOneTimePurchaseMode) && !isTrialMode() -->
             <div class="field choice">
                     <input type="radio"
                            name="subscription_option[option]"


### PR DESCRIPTION
This pull request adds:

* Trial product support on cart and product details pages
    * This removes the one-time option, similar to 'subscription only' products
    * On the PDP, this also adds the trial price that will override the product's base price.
    * On the cart, this adds a "Trial Subscription" message in the subscription widget.
* Override the normal product price with the trial price configured in Subscribe Pro.