### PR TITLE
[#160321445] Suppress and log error message in admin checkout

### DIFF
--- a/Block/Adminhtml/System/Config/Config.php
+++ b/Block/Adminhtml/System/Config/Config.php
@@ -51,8 +51,8 @@ class Config extends \Magento\Framework\View\Element\Template
         try {
             $config = $this->gatewayConfigProvider->getConfig($storeId);
         } catch (InvalidArgumentException $e) {
-            $config = [];
-            $this->logger->debug('Cannog retrieve Subscribe Pro payment config: ' . $e->getMessage());
+            $config = null;
+            $this->logger->debug('Cannot retrieve Subscribe Pro payment config: ' . $e->getMessage());
         }
 
         return json_encode($config);


### PR DESCRIPTION
Error message occurs when credentials are not supplied but subscription features are enabled.