### PR TITLE
Fix updating delivery address on My Subscriptions page

### DIFF
--- a/view/frontend/web/js/view/subscription/shipping-info.js
+++ b/view/frontend/web/js/view/subscription/shipping-info.js
@@ -37,6 +37,8 @@ define(
                 isAddressFormVisible: false
             },
 
+            isFormInline: false,
+
             addressOptions: null,
 
             initObservable: function () {

--- a/view/frontend/web/template/subscription/shipping-info.html
+++ b/view/frontend/web/template/subscription/shipping-info.html
@@ -26,5 +26,5 @@
     <!--/ko-->
 
     <!-- ko template: 'Swarming_SubscribePro/subscription/shipping-list' --><!-- /ko -->
-    <!-- ko template: 'Magento_Checkout/billing-address/form' --><!-- /ko -->
+    <!-- ko template: 'Magento_Checkout/shipping-address/form' --><!-- /ko -->
 </div>


### PR DESCRIPTION
Our extension has been using the billing address form to pull in the address fields when updating the delivery address on the My Subscriptions page. That template was changed in 2.2.6 to use a getCode() function, which was not being defined in our extension before including the template, causing an error. I have changed it to use the shipping address form instead, which doesn't use the getCode() function.

The isFormInline parameter is used in the shipping address form to determine whether the "save in address book" checkbox will be shown.