### PR TITLE
layout: add module prefix to template definitions

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="product.info.options.wrapper.bottom">
-            <block class="Swarming\SubscribePro\Block\Product\Subscription" name="product.info.subscription.options" before="product.info.addtocart" as="subscription-option" template="product/subscription.phtml">
+            <block class="Swarming\SubscribePro\Block\Product\Subscription" name="product.info.subscription.options" before="product.info.addtocart" as="subscription-option" template="Swarming_SubscribePro::product/subscription.phtml">
                 <arguments>
                     <argument name="jsLayout" xsi:type="array">
                         <item name="components" xsi:type="array">

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="additional.product.info">
-            <block class="Swarming\SubscribePro\Block\Cart\Subscription" name="cart.product.subscription" after="-" template="cart/subscription.phtml">
+            <block class="Swarming\SubscribePro\Block\Cart\Subscription" name="cart.product.subscription" after="-" template="Swarming_SubscribePro::cart/subscription.phtml">
                 <arguments>
                     <argument name="subscription-container-component" xsi:type="array">
                         <item name="component" xsi:type="string">Swarming_SubscribePro/js/view/cart/subscription</item>

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="order.success.additional.info">
-            <block class="Swarming\SubscribePro\Block\Checkout\Onepage\Success\Subscriptions" name="onepage.success.subscriptions" template="checkout/onepage/success/subscriptions.phtml"/>
+            <block class="Swarming\SubscribePro\Block\Checkout\Onepage\Success\Subscriptions" name="onepage.success.subscriptions" template="Swarming_SubscribePro::checkout/onepage/success/subscriptions.phtml"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
The missing module prefix in template definitions creates issues if you need to preference or change the block class for an existing block name. All other template definitions included the module prefix already.