### PR TITLE
Updated block to use sort order

### DIFF
--- a/view/frontend/layout/customer_account.xml
+++ b/view/frontend/layout/customer_account.xml
@@ -2,10 +2,11 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="customer_account_navigation">
-            <block ifconfig="swarming_subscribepro/general/enabled" class="Magento\Framework\View\Element\Html\Link\Current" name="customer-account-navigation-swarming-subscribepro-subscription-link">
+            <block ifconfig="swarming_subscribepro/general/enabled" class="Magento\Customer\Block\Account\SortLinkInterface" name="customer-account-navigation-swarming-subscribepro-subscription-link">
                 <arguments>
                     <argument name="path" xsi:type="string">swarming_subscribepro/customer/subscriptions</argument>
                     <argument name="label" translate="true" xsi:type="string">My Product Subscriptions</argument>
+                    <argument name="sortOrder" xsi:type="number">150</argument>
                 </arguments>
             </block>
         </referenceBlock>


### PR DESCRIPTION
This allows themes to adjust the sorting of the link instead of it forcing itself to the bottom position. This will prevent the need for themes to remove and recreate the block if sorting is required.