### PR TITLE
Adds option to use child SKU for configurable products when creating subscriptions

### DIFF
--- a/Model/Config/SubscriptionOptions.php
+++ b/Model/Config/SubscriptionOptions.php
@@ -69,4 +69,13 @@ class SubscriptionOptions extends General
     {
         return (int) $this->scopeConfig->getValue('swarming_subscribepro/subscription_options/my_subscriptions_count', ScopeInterface::SCOPE_WEBSITE, $websiteCode);
     }
+
+    /**
+     * @param string|null $websiteCode
+     * @return bool
+     */
+    public function isChildSkuForConfigurableEnabled($websiteCode = null)
+    {
+        return $this->scopeConfig->isSetFlag('swarming_subscribepro/subscription_options/use_child_sku_when_configurable', ScopeInterface::SCOPE_WEBSITE, $websiteCode);
+    }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -107,6 +107,15 @@
                     </depends>
                     <validate>validate-number validate-greater-than-zero</validate>
                 </field>
+
+                <field id="use_child_sku_when_configurable" translate="label comment" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Use Child Sku For Subscription When Configurable</label>
+                    <comment>When enabled, creating a subscription for a configurable product uses the child SKU instead of the configurable product SKU</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="swarming_subscribepro/general/enabled">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="subscription_discount" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Subscription Discount</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,6 +15,7 @@
                 <allow_coupon>0</allow_coupon>
                 <allow_cancel>1</allow_cancel>
                 <my_subscriptions_count>25</my_subscriptions_count>
+                <use_child_sku_when_configurable>0</use_child_sku_when_configurable>
             </subscription_options>
             <subscription_discount>
                 <apply_discount_to_catalog_price>0</apply_discount_to_catalog_price>


### PR DESCRIPTION
Adds a flag to the admin that adds the option to use the child SKU for configurable products when creating a subscription.
Be default, this is turned off (uses configurable product SKU) for backwards compatibility since that's how it works currently.