### PR TITLE
Added 2.4.5 comaptibility for datepicker widget

### DIFF
--- a/view/frontend/web/js/action/subscription/load-list.js
+++ b/view/frontend/web/js/action/subscription/load-list.js
@@ -16,7 +16,7 @@ define(
                 function (response) {
                     callback(response);
                 }
-            ).error(
+            ).fail(
                 function (response) {
                     errorProcessor.process(response);
                     subscriptionLoader.isLoading(false);

--- a/view/frontend/web/js/view/subscription/item.js
+++ b/view/frontend/web/js/view/subscription/item.js
@@ -36,6 +36,7 @@ define(
 
                 this.nextOrderDate(this.subscription.next_order_date);
                 this.selectedNextOrderDate(this.subscription.next_order_date);
+                this.value = ko.observable('');
                 this.qty(this.subscription.qty);
                 this.selectedQty(this.subscription.qty);
                 this.interval(this.subscription.interval);
@@ -53,6 +54,7 @@ define(
                         'showDetails',
                         'nextOrderDate',
                         'selectedNextOrderDate',
+                        'value',
                         'qty',
                         'selectedQty',
                         'interval',


### PR DESCRIPTION
This fixes #154 for the changed mage/storage promise flow and datepicker value assignment
- Magento deprecated error handling function to fail() from error()
- Datepicker needs a `value` observable on the parent object.