### PR TITLE
#225 Wallet page - API Url must come from configuration

### DIFF
--- a/view/frontend/web/js/view/vault/card.js
+++ b/view/frontend/web/js/view/vault/card.js
@@ -81,8 +81,9 @@ define(
                     console.log(data);
                 });
                 let authConfig = config.getConfig().sessionAccessToken;
+                let apiBaseUrl = config.getConfig().apiBaseUrl;
                 PaymentFields.init({
-                    apiBaseUrl: 'https://api.subscribepro.com/',
+                    apiBaseUrl: apiBaseUrl,
                     oauthApiToken: authConfig.access_token,
                     spVaultEnvironmentId: authConfig.sp_vault_environment_id,
                     paymentMethodType: 'credit_card',


### PR DESCRIPTION
feat: Add API URL from the configuration on the wallet page.

Refs: #225