### PR TITLE
#182 Order Callback | Interval value not stored in sales_order_item and not shown in order email. 

### DIFF
--- a/Model/Quote/SubscriptionOption/Updater.php
+++ b/Model/Quote/SubscriptionOption/Updater.php
@@ -54,7 +54,7 @@ class Updater
             $createNewSubscriptionAtCheckout = true;
         }
 
-        if (!$createNewSubscriptionAtCheckout) {
+        if (!$createNewSubscriptionAtCheckout && !$this->quoteItemHelper->isItemFulfilsSubscription($quoteItem)) {
             $subscriptionInterval = null;
         }
 


### PR DESCRIPTION
feat: Fix interval value for callback orders.

Refs: #182