### PR TITLE
fix: Not displaying correct cart rule labels in cart

### DIFF
--- a/Model/Quote/ItemSubscriptionDiscount.php
+++ b/Model/Quote/ItemSubscriptionDiscount.php
@@ -7,7 +7,7 @@ use Magento\Quote\Model\Quote\Item\AbstractItem as QuoteItem;
 
 class ItemSubscriptionDiscount
 {
-    public const KEY_DISCOUNT_DESCRIPTION = 'subscription';
+    public const KEY_DISCOUNT_DESCRIPTION = "subscription";
 
     /**
      * @var \Swarming\SubscribePro\Model\Config\SubscriptionDiscount
@@ -46,7 +46,7 @@ class ItemSubscriptionDiscount
         \Swarming\SubscribePro\Platform\Manager\Product $platformProductManager,
         \Swarming\SubscribePro\Helper\QuoteItem $quoteItemHelper,
         \Magento\Framework\Pricing\PriceCurrencyInterface $priceCurrency,
-        \Swarming\SubscribePro\Helper\SalesRuleValidator $salesRuleValidatorHelper
+        \Swarming\SubscribePro\Helper\SalesRuleValidator $salesRuleValidatorHelper,
     ) {
         $this->subscriptionDiscountConfig = $subscriptionDiscountConfig;
         $this->platformProductManager = $platformProductManager;
@@ -59,25 +59,56 @@ class ItemSubscriptionDiscount
      * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
      * @param float $itemBasePrice
      * @param callable $rollbackCallback
+     * @param string|null $subscriptionLabel
      */
-    public function processSubscriptionDiscount(QuoteItem $item, $itemBasePrice, callable $rollbackCallback)
-    {
+    public function processSubscriptionDiscount(
+        QuoteItem $item,
+        $itemBasePrice,
+        callable $rollbackCallback,
+        $subscriptionLabel = null,
+    ) {
         $storeId = $item->getQuote()->getStoreId();
         $baseCartDiscount = $item->getBaseDiscountAmount();
 
         $platformProduct = $this->getPlatformProduct($item);
         $baseSubscriptionDiscount = $subscriptionDiscount = $this->priceCurrency->convertAndRound(
-            $this->getBaseSubscriptionDiscount($platformProduct, $itemBasePrice, $item->getQty()),
-            $storeId
+            $this->getBaseSubscriptionDiscount(
+                $platformProduct,
+                $itemBasePrice,
+                $item->getQty(),
+            ),
+            $storeId,
         );
 
-        if ($this->isOnlySubscriptionDiscount($baseSubscriptionDiscount, $baseCartDiscount, $storeId)) {
+        if (
+            $this->isOnlySubscriptionDiscount(
+                $baseSubscriptionDiscount,
+                $baseCartDiscount,
+                $storeId,
+            )
+        ) {
+            // Subscription discount wins - rollback cart rules and apply subscription
             $rollbackCallback($item);
-            $this->setSubscriptionDiscount($item, $subscriptionDiscount, $baseSubscriptionDiscount);
-            $this->addDiscountDescription($item);
+            $this->setSubscriptionDiscount(
+                $item,
+                $subscriptionDiscount,
+                $baseSubscriptionDiscount,
+            );
+            $this->setSubscriptionDiscountDescription(
+                $item,
+                $subscriptionLabel,
+            );
         } elseif ($this->isCombineDiscounts($storeId)) {
-            $this->addSubscriptionDiscount($item, $subscriptionDiscount, $baseSubscriptionDiscount);
-            $this->addDiscountDescription($item);
+            // Combine mode - add subscription discount to cart discount, keep both labels
+            $this->addSubscriptionDiscount(
+                $item,
+                $subscriptionDiscount,
+                $baseSubscriptionDiscount,
+            );
+            // Labels are already combined (SP label added when rule processed, cart label from before)
+        } else {
+            // Cart discount wins - rollback to remove Subscribe Pro rule and label
+            $rollbackCallback($item);
         }
     }
 
@@ -86,16 +117,27 @@ class ItemSubscriptionDiscount
      * @param float $subscriptionDiscount
      * @param float $baseSubscriptionDiscount
      */
-    protected function setSubscriptionDiscount(QuoteItem $item, $subscriptionDiscount, $baseSubscriptionDiscount)
-    {
+    protected function setSubscriptionDiscount(
+        QuoteItem $item,
+        $subscriptionDiscount,
+        $baseSubscriptionDiscount,
+    ) {
         if ($item->getChildren() && $item->isChildrenCalculated()) {
             $childItemCount = count($item->getChildren());
-            $childSubscriptionDiscount = round(($subscriptionDiscount * 1.0) / $childItemCount, 2);
-            $childBaseSubscriptionDiscount = round(($baseSubscriptionDiscount * 1.0) / $childItemCount, 2);
+            $childSubscriptionDiscount = round(
+                ($subscriptionDiscount * 1.0) / $childItemCount,
+                2,
+            );
+            $childBaseSubscriptionDiscount = round(
+                ($baseSubscriptionDiscount * 1.0) / $childItemCount,
+                2,
+            );
 
             foreach ($item->getChildren() as $childItem) {
                 $childItem->setDiscountAmount($childSubscriptionDiscount);
-                $childItem->setBaseDiscountAmount($childBaseSubscriptionDiscount);
+                $childItem->setBaseDiscountAmount(
+                    $childBaseSubscriptionDiscount,
+                );
             }
         } else {
             $item->setDiscountAmount($subscriptionDiscount);
@@ -108,36 +150,60 @@ class ItemSubscriptionDiscount
      * @param float $subscriptionDiscount
      * @param float $baseSubscriptionDiscount
      */
-    protected function addSubscriptionDiscount(QuoteItem $item, $subscriptionDiscount, $baseSubscriptionDiscount)
-    {
+    protected function addSubscriptionDiscount(
+        QuoteItem $item,
+        $subscriptionDiscount,
+        $baseSubscriptionDiscount,
+    ) {
         if ($item->getChildren() && $item->isChildrenCalculated()) {
             $childItemCount = count($item->getChildren());
-            $childSubscriptionDiscount = round(($subscriptionDiscount * 1.0) / $childItemCount, 2);
-            $childBaseSubscriptionDiscount = round(($baseSubscriptionDiscount * 1.0) / $childItemCount, 2);
+            $childSubscriptionDiscount = round(
+                ($subscriptionDiscount * 1.0) / $childItemCount,
+                2,
+            );
+            $childBaseSubscriptionDiscount = round(
+                ($baseSubscriptionDiscount * 1.0) / $childItemCount,
+                2,
+            );
 
             foreach ($item->getChildren() as $childItem) {
-                $newDiscountAmount = $childItem->getDiscountAmount() + $childSubscriptionDiscount;
+                $newDiscountAmount =
+                    $childItem->getDiscountAmount() +
+                    $childSubscriptionDiscount;
                 $childItem->setDiscountAmount($newDiscountAmount);
 
-                $newBaseDiscountAmount = $childItem->getBaseDiscountAmount() + $childBaseSubscriptionDiscount;
+                $newBaseDiscountAmount =
+                    $childItem->getBaseDiscountAmount() +
+                    $childBaseSubscriptionDiscount;
                 $childItem->setBaseDiscountAmount($newBaseDiscountAmount);
             }
         } else {
-            $newDiscountAmount = $item->getDiscountAmount() + $subscriptionDiscount;
+            $newDiscountAmount =
+                $item->getDiscountAmount() + $subscriptionDiscount;
             $item->setDiscountAmount($newDiscountAmount);
 
-            $newBaseDiscountAmount = $item->getBaseDiscountAmount() + $baseSubscriptionDiscount;
+            $newBaseDiscountAmount =
+                $item->getBaseDiscountAmount() + $baseSubscriptionDiscount;
             $item->setBaseDiscountAmount($newBaseDiscountAmount);
         }
     }
 
     /**
+     * Set discount description to show only subscription label
+     *
      * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
+     * @param string|null $subscriptionLabel
      */
-    protected function addDiscountDescription(QuoteItem $item)
-    {
-        $discountDescriptions = $item->getAddress()->getDiscountDescriptionArray();
-        $item->getAddress()->setDiscountDescriptionArray($discountDescriptions);
+    protected function setSubscriptionDiscountDescription(
+        QuoteItem $item,
+        $subscriptionLabel = null,
+    ) {
+        // Use the provided subscription label, or fall back to "Subscription"
+        $label = $subscriptionLabel ?: __("Subscription");
+
+        $item->getAddress()->setDiscountDescriptionArray([
+            self::KEY_DISCOUNT_DESCRIPTION => $label,
+        ]);
     }
 
     /**
@@ -147,7 +213,10 @@ class ItemSubscriptionDiscount
     protected function getPlatformProduct(QuoteItem $item)
     {
         $sku = $item->getProduct()->getData(ProductInterface::SKU);
-        return $this->platformProductManager->getProduct($sku, $item->getQuote()->getStore()->getWebsiteId());
+        return $this->platformProductManager->getProduct(
+            $sku,
+            $item->getQuote()->getStore()->getWebsiteId(),
+        );
     }
 
     /**
@@ -156,13 +225,16 @@ class ItemSubscriptionDiscount
      * @param float $qty
      * @return float
      */
-    protected function getBaseSubscriptionDiscount($platformProduct, $itemBasePrice, $qty)
-    {
+    protected function getBaseSubscriptionDiscount(
+        $platformProduct,
+        $itemBasePrice,
+        $qty,
+    ) {
         return $this->salesRuleValidatorHelper->getBaseSubscriptionDiscount(
             $platformProduct->getIsDiscountPercentage(),
             $platformProduct->getDiscount(),
             $itemBasePrice,
-            $qty
+            $qty,
         );
     }
 
@@ -173,12 +245,15 @@ class ItemSubscriptionDiscount
      *
      * @return bool
      */
-    protected function isOnlySubscriptionDiscount($baseSubscriptionDiscount, $baseCartDiscount, $storeId)
-    {
+    protected function isOnlySubscriptionDiscount(
+        $baseSubscriptionDiscount,
+        $baseCartDiscount,
+        $storeId,
+    ) {
         return $this->salesRuleValidatorHelper->isOnlySubscriptionDiscount(
             $baseSubscriptionDiscount,
             $baseCartDiscount,
-            $this->subscriptionDiscountConfig->getCartRuleCombineType($storeId)
+            $this->subscriptionDiscountConfig->getCartRuleCombineType($storeId),
         );
     }
 
@@ -189,7 +264,7 @@ class ItemSubscriptionDiscount
     protected function isCombineDiscounts($storeId)
     {
         return $this->salesRuleValidatorHelper->isCombineDiscounts(
-            $this->subscriptionDiscountConfig->getCartRuleCombineType($storeId)
+            $this->subscriptionDiscountConfig->getCartRuleCombineType($storeId),
         );
     }
 }

--- a/Plugin/SalesRule/Validator.php
+++ b/Plugin/SalesRule/Validator.php
@@ -9,9 +9,9 @@ use Magento\SalesRule\Model\Validator as SalesRuleValidator;
 
 class Validator
 {
-    public const QUOTE_ITEM_RULES = 'quoteItemRules';
-    public const QUOTE_RULES = 'quoteRules';
-    public const ADDRESS_RULES = 'addressRules';
+    public const QUOTE_ITEM_RULES = "quoteItemRules";
+    public const QUOTE_RULES = "quoteRules";
+    public const ADDRESS_RULES = "addressRules";
 
     /**
      * @var \Swarming\SubscribePro\Model\Config\SubscriptionDiscount
@@ -43,7 +43,7 @@ class Validator
         \Swarming\SubscribePro\Model\Config\SubscriptionDiscount $subscriptionDiscountConfig,
         \Swarming\SubscribePro\Model\Quote\ItemSubscriptionDiscount $itemSubscriptionDiscount,
         \Swarming\SubscribePro\Model\CatalogRule\InspectorInterface $catalogRuleInspector,
-        \Swarming\SubscribePro\Helper\QuoteItem $quoteItemHelper
+        \Swarming\SubscribePro\Helper\QuoteItem $quoteItemHelper,
     ) {
         $this->subscriptionDiscountConfig = $subscriptionDiscountConfig;
         $this->itemSubscriptionDiscount = $itemSubscriptionDiscount;
@@ -59,19 +59,42 @@ class Validator
      *
      * @return \Magento\SalesRule\Model\Validator
      */
-    public function aroundProcess(SalesRuleValidator $subject, \Closure $proceed, AbstractItem $item, Rule $rule)
-    {
+    public function aroundProcess(
+        SalesRuleValidator $subject,
+        \Closure $proceed,
+        AbstractItem $item,
+        Rule $rule,
+    ) {
+        // Only capture state for Subscribe Pro Discount rule to avoid overhead
+        if ($rule->getName() !== "Subscribe Pro Discount") {
+            return $proceed($item, $rule);
+        }
+
+        // Capture state before Subscribe Pro Discount rule processes
         $appliedRuleIds = [
             self::QUOTE_ITEM_RULES => $item->getAppliedRuleIds(),
             self::QUOTE_RULES => $item->getQuote()->getAppliedRuleIds(),
             self::ADDRESS_RULES => $item->getAddress()->getAppliedRuleIds(),
         ];
-        $discountDescriptions = (array)$item->getAddress()->getDiscountDescriptionArray();
+        $discountDescriptions = (array) $item
+            ->getAddress()
+            ->getDiscountDescriptionArray();
 
+        // Process the Subscribe Pro Discount rule
         $result = $proceed($item, $rule);
 
-        if ($rule->getName() !== 'Subscribe Pro Discount') {
-            return $result;
+        // Capture the Subscribe Pro rule's label after it processes
+        $subscriptionLabel = null;
+        $descriptionsAfter = (array) $item
+            ->getAddress()
+            ->getDiscountDescriptionArray();
+        // Find the label that was added by the Subscribe Pro rule
+        $newDescriptions = array_diff_assoc(
+            $descriptionsAfter,
+            $discountDescriptions,
+        );
+        if (!empty($newDescriptions)) {
+            $subscriptionLabel = reset($newDescriptions);
         }
 
         $websiteId = $item->getQuote()->getStore()->getWebsiteId();
@@ -84,8 +107,11 @@ class Validator
         }
 
         $storeCode = $item->getQuote()->getStore()->getCode();
-        if ($this->catalogRuleInspector->isApplied($item->getProduct())
-            && !$this->subscriptionDiscountConfig->isApplyDiscountToCatalogPrice($storeCode)
+        if (
+            $this->catalogRuleInspector->isApplied($item->getProduct()) &&
+            !$this->subscriptionDiscountConfig->isApplyDiscountToCatalogPrice(
+                $storeCode,
+            )
         ) {
             return $result;
         }
@@ -93,7 +119,8 @@ class Validator
         $this->itemSubscriptionDiscount->processSubscriptionDiscount(
             $item,
             $subject->getItemBasePrice($item),
-            $this->getRollbackCallback($appliedRuleIds, $discountDescriptions)
+            $this->getRollbackCallback($appliedRuleIds, $discountDescriptions),
+            $subscriptionLabel,
         );
 
         return $result;
@@ -105,14 +132,27 @@ class Validator
      * @return callable
      * @codeCoverageIgnore
      */
-    protected function getRollbackCallback($appliedRuleIds, $discountDescriptions)
-    {
-        return function (QuoteItem $item) use ($appliedRuleIds, $discountDescriptions) {
+    protected function getRollbackCallback(
+        $appliedRuleIds,
+        $discountDescriptions,
+    ) {
+        return function (QuoteItem $item) use (
+            $appliedRuleIds,
+            $discountDescriptions,
+        ) {
             $item->setAppliedRuleIds($appliedRuleIds[self::QUOTE_ITEM_RULES]);
-            $item->getAddress()->setAppliedRuleIds($appliedRuleIds[self::ADDRESS_RULES]); /* @phpstan-ignore-line */
-            $item->getQuote()->setAppliedRuleIds($appliedRuleIds[self::QUOTE_RULES]);
+            $item
+                ->getAddress()
+                ->setAppliedRuleIds(
+                    $appliedRuleIds[self::ADDRESS_RULES],
+                ); /* @phpstan-ignore-line */
+            $item
+                ->getQuote()
+                ->setAppliedRuleIds($appliedRuleIds[self::QUOTE_RULES]);
 
-            $item->getAddress()->setDiscountDescriptionArray($discountDescriptions);
+            $item
+                ->getAddress()
+                ->setDiscountDescriptionArray($discountDescriptions);
         };
     }
 }


### PR DESCRIPTION
Fixes: #283 

The discounting is working as expected based on the configured cart rule combine type. The issue is that it requires the `Subscribe Pro Discount` cart rule to have the lowest  priority ie. 999 so that it is applied last.