### PR TITLE
fix: Display correct cart rule labels

### DIFF
--- a/Model/Quote/ItemSubscriptionDiscount.php
+++ b/Model/Quote/ItemSubscriptionDiscount.php
@@ -59,8 +59,9 @@ class ItemSubscriptionDiscount
      * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
      * @param float $itemBasePrice
      * @param callable $rollbackCallback
+     * @param string|null $subscriptionLabel
      */
-    public function processSubscriptionDiscount(QuoteItem $item, $itemBasePrice, callable $rollbackCallback)
+    public function processSubscriptionDiscount(QuoteItem $item, $itemBasePrice, callable $rollbackCallback, $subscriptionLabel = null)
     {
         $storeId = $item->getQuote()->getStoreId();
         $baseCartDiscount = $item->getBaseDiscountAmount();
@@ -74,10 +75,11 @@ class ItemSubscriptionDiscount
         if ($this->isOnlySubscriptionDiscount($baseSubscriptionDiscount, $baseCartDiscount, $storeId)) {
             $rollbackCallback($item);
             $this->setSubscriptionDiscount($item, $subscriptionDiscount, $baseSubscriptionDiscount);
-            $this->addDiscountDescription($item);
+            $this->setSubscriptionDiscountDescription($item, $subscriptionLabel);
         } elseif ($this->isCombineDiscounts($storeId)) {
             $this->addSubscriptionDiscount($item, $subscriptionDiscount, $baseSubscriptionDiscount);
-            $this->addDiscountDescription($item);
+        } else {
+            $rollbackCallback($item);
         }
     }
 
@@ -133,11 +135,15 @@ class ItemSubscriptionDiscount
 
     /**
      * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
+     * @param string|null $subscriptionLabel
      */
-    protected function addDiscountDescription(QuoteItem $item)
+    protected function setSubscriptionDiscountDescription(QuoteItem $item, $subscriptionLabel = null)
     {
-        $discountDescriptions = $item->getAddress()->getDiscountDescriptionArray();
-        $item->getAddress()->setDiscountDescriptionArray($discountDescriptions);
+        $label = $subscriptionLabel ?: __("Subscription");
+
+        $item->getAddress()->setDiscountDescriptionArray([
+            self::KEY_DISCOUNT_DESCRIPTION => $label,
+        ]);
     }
 
     /**

--- a/Plugin/SalesRule/Validator.php
+++ b/Plugin/SalesRule/Validator.php
@@ -61,6 +61,10 @@ class Validator
      */
     public function aroundProcess(SalesRuleValidator $subject, \Closure $proceed, AbstractItem $item, Rule $rule)
     {
+        if ($rule->getName() !== 'Subscribe Pro Discount') {
+            return $proceed($item, $rule);
+        }
+
         $appliedRuleIds = [
             self::QUOTE_ITEM_RULES => $item->getAppliedRuleIds(),
             self::QUOTE_RULES => $item->getQuote()->getAppliedRuleIds(),
@@ -70,8 +74,11 @@ class Validator
 
         $result = $proceed($item, $rule);
 
-        if ($rule->getName() !== 'Subscribe Pro Discount') {
-            return $result;
+        $subscriptionLabel = null;
+        $descriptionsAfter = (array)$item->getAddress()->getDiscountDescriptionArray();
+        $newDescriptions = array_diff_assoc($descriptionsAfter, $discountDescriptions);
+        if (!empty($newDescriptions)) {
+            $subscriptionLabel = reset($newDescriptions);
         }
 
         $websiteId = $item->getQuote()->getStore()->getWebsiteId();
@@ -93,7 +100,8 @@ class Validator
         $this->itemSubscriptionDiscount->processSubscriptionDiscount(
             $item,
             $subject->getItemBasePrice($item),
-            $this->getRollbackCallback($appliedRuleIds, $discountDescriptions)
+            $this->getRollbackCallback($appliedRuleIds, $discountDescriptions),
+            $subscriptionLabel
         );
 
         return $result;


### PR DESCRIPTION
Fixes: #283

The discounting is working as expected based on the configured cart rule combine type. The issue is that it requires the Subscribe Pro Discount cart rule to have the lowest priority ie. 999 so that it is applied last.